### PR TITLE
fix: playlists not loading after login

### DIFF
--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/library/LibraryPlaylistsScreen.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/library/LibraryPlaylistsScreen.kt
@@ -175,13 +175,13 @@ fun LibraryPlaylistsScreen(
         backStackEntry?.savedStateHandle?.getStateFlow("scrollToTop", false)?.collectAsState()
 
     val (innerTubeCookie) = rememberPreference(InnerTubeCookieKey, "")
-    remember(innerTubeCookie) {
+    val isLoggedIn = remember(innerTubeCookie) {
         "SAPISID" in parseCookieString(innerTubeCookie)
     }
 
     val (ytmSync) = rememberPreference(YtmSyncKey, true)
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(isLoggedIn, ytmSync) {
         if (ytmSync) {
             withContext(Dispatchers.IO) {
                 viewModel.sync()

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/library/NeonLibraryScreen.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/library/NeonLibraryScreen.kt
@@ -29,10 +29,15 @@ import androidx.navigation.NavController
 import coil.compose.AsyncImage
 import com.darkxvenom.airbeats.LocalPlayerAwareWindowInsets
 import com.darkxvenom.airbeats.R
+import com.darkxvenom.airbeats.constants.InnerTubeCookieKey
+import com.darkxvenom.airbeats.innertube.utils.parseCookieString
 import com.darkxvenom.airbeats.ui.component.CreatePlaylistDialog
 import com.darkxvenom.airbeats.ui.screens.NeonDarkBg
 import com.darkxvenom.airbeats.ui.screens.NeonPurple
+import com.darkxvenom.airbeats.utils.rememberPreference
 import com.darkxvenom.airbeats.viewmodels.LibraryPlaylistsViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import java.util.UUID
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -50,6 +55,17 @@ fun NeonLibraryScreen(
     
     val playlists by viewModel.allPlaylists.collectAsState()
     val topSize by viewModel.topValue.collectAsState(initial = 50)
+
+    val (innerTubeCookie) = rememberPreference(InnerTubeCookieKey, "")
+    val isLoggedIn = remember(innerTubeCookie) {
+        "SAPISID" in parseCookieString(innerTubeCookie)
+    }
+
+    LaunchedEffect(isLoggedIn) {
+        withContext(Dispatchers.IO) {
+            viewModel.sync()
+        }
+    }
     
     var showCreatePlaylistDialog by remember { mutableStateOf(false) }
     var showSpotifyImportDialog by remember { mutableStateOf(false) }

--- a/app/src/main/java/com/darkxvenom/airbeats/utils/SyncUtils.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/utils/SyncUtils.kt
@@ -122,35 +122,39 @@ class SyncUtils @Inject constructor(
     }
 
     suspend fun syncSavedPlaylists() {
-        YouTube.library("FEmusic_liked_playlists").completedLibraryPage().onSuccess { page ->
-            val playlistList = page.items.filterIsInstance<PlaylistItem>()
-                .filterNot { it.id == "LM" ||  it.id == "SE" }
-                .reversed()
-            val dbPlaylists = database.playlistsByNameAsc().first()
+        YouTube.library("FEmusic_liked_playlists").completedLibraryPage()
+            .onSuccess { page ->
+                val playlistList = page.items.filterIsInstance<PlaylistItem>()
+                    .filterNot { it.id == "LM" ||  it.id == "SE" }
+                    .reversed()
+                val dbPlaylists = database.playlistsByNameAsc().first()
 
-            dbPlaylists.filterNot { it.playlist.browseId in playlistList.map(PlaylistItem::id) }
-                .filterNot { it.playlist.browseId == null }
-                .forEach { database.update(it.playlist.localToggleLike()) }
+                dbPlaylists.filterNot { it.playlist.browseId in playlistList.map(PlaylistItem::id) }
+                    .filterNot { it.playlist.browseId == null }
+                    .forEach { database.update(it.playlist.localToggleLike()) }
 
-            playlistList.onEach { playlist ->
-                var playlistEntity = dbPlaylists.find { playlist.id == it.playlist.browseId }?.playlist
-                if (playlistEntity == null) {
-                    playlistEntity = PlaylistEntity(
-                        name = playlist.title,
-                        browseId = playlist.id,
-                        isEditable = playlist.isEditable,
-                        bookmarkedAt = LocalDateTime.now(),
-                        remoteSongCount = playlist.songCountText?.let {
-                            Regex("""\d+""").find(it)?.value?.toIntOrNull()
-                        }
-                    )
+                playlistList.onEach { playlist ->
+                    var playlistEntity = dbPlaylists.find { playlist.id == it.playlist.browseId }?.playlist
+                    if (playlistEntity == null) {
+                        playlistEntity = PlaylistEntity(
+                            name = playlist.title,
+                            browseId = playlist.id,
+                            isEditable = playlist.isEditable,
+                            bookmarkedAt = LocalDateTime.now(),
+                            remoteSongCount = playlist.songCountText?.let {
+                                Regex("""\d+""").find(it)?.value?.toIntOrNull()
+                            }
+                        )
 
-                    database.insert(playlistEntity)
-                } else database.update(playlistEntity, playlist)
+                        database.insert(playlistEntity)
+                    } else database.update(playlistEntity, playlist)
 
-                syncPlaylist(playlist.id, playlistEntity.id)
+                    syncPlaylist(playlist.id, playlistEntity.id)
+                }
             }
-        }
+            .onFailure { exception ->
+                reportException(exception)
+            }
     }
 
     suspend fun syncPlaylist(browseId: String, playlistId: String) {


### PR DESCRIPTION
## Description
Fixes playlists not syncing/loading after user logs in.

### Changes:
- **LibraryPlaylistsScreen.kt**: Track `isLoggedIn` state and re-trigger sync when login state or sync preference changes
- **NeonLibraryScreen.kt**: Add login-aware sync trigger so playlists sync after login on the library screen too
- **SyncUtils.kt**: Add `.onFailure` error handling for playlist sync and fix code formatting

### What this fixes:
Previously, playlist sync only ran once on screen load (`LaunchedEffect(Unit)`). If the user wasnt logged in at load time, sync would silently fail and never retry. Now it properly watches the login state and re-syncs when the user logs in.