### PR TITLE
feat(voice): Full Voice Assistant Engine, Vector HUD Badges, and Offline Library Playback

### DIFF
--- a/app/google-services.json
+++ b/app/google-services.json
@@ -1,0 +1,48 @@
+{
+  "project_info": {
+    "project_number": "1234567890",
+    "project_id": "airbeats-music",
+    "storage_bucket": "airbeats-music.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1234567890:android:abcdef1234567890",
+        "android_client_info": {
+          "package_name": "com.darkxvenom.airbeats"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDummyApiKeyForBuildingAirBeats000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    },
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:1234567890:android:abcdef1234567891",
+        "android_client_info": {
+          "package_name": "com.darkxvenom.airbeats.debug"
+        }
+      },
+      "oauth_client": [],
+      "api_key": [
+        {
+          "current_key": "AIzaSyDummyApiKeyForBuildingAirBeats000"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": []
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/app/src/main/java/com/darkxvenom/airbeats/db/DatabaseDao.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/db/DatabaseDao.kt
@@ -65,6 +65,10 @@ private fun <T> List<T>.sortedWithCollator(selector: (T) -> String): List<T> {
 @Dao
 interface DatabaseDao {
     @Transaction
+    @Query("SELECT * FROM song WHERE title LIKE '%' || :query || '%' OR albumName LIKE '%' || :query || '%' ORDER BY rowId DESC")
+    fun searchLocalSongs(query: String): Flow<List<Song>>
+
+    @Transaction
     @Query("SELECT * FROM song WHERE inLibrary IS NOT NULL ORDER BY rowId")
     fun songsByRowIdAsc(): Flow<List<Song>>
 

--- a/app/src/main/java/com/darkxvenom/airbeats/playback/PlayerConnection.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/playback/PlayerConnection.kt
@@ -413,8 +413,12 @@ class PlayerConnection(
     fun seekToPrevious() {
         try {
             Log.d(TAG, "Seeking to previous track")
-            if (player.hasPreviousMediaItem() || player.currentPosition > 3000) {
-                player.seekToPrevious()
+            if (player.hasPreviousMediaItem()) {
+                player.seekToPreviousMediaItem()
+                player.prepare()
+                player.playWhenReady = true
+            } else {
+                player.seekTo(0)
                 player.prepare()
                 player.playWhenReady = true
             }

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/component/NameSetupDialog.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/component/NameSetupDialog.kt
@@ -1,34 +1,59 @@
 package com.darkxvenom.airbeats.ui.component
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import com.darkxvenom.airbeats.R
 
 @Composable
@@ -38,87 +63,198 @@ fun NameSetupDialog(
     var nameInput by remember { mutableStateOf(TextFieldValue("")) }
     val focusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
-    val isNameValid = nameInput.text.length in 1..9
+    val trimmedName = nameInput.text.trim()
+    val isNameValid = trimmedName.isNotEmpty() && trimmedName.length <= 16
 
-    AlertDialog(
+    val isDark = isSystemInDarkTheme()
+    val dialogBgColor = if (isDark) Color(0xFF181820) else Color(0xFFFFFFFF)
+    val textColor = if (isDark) Color(0xFFEEEEF2) else Color(0xFF1A1A24)
+    val subTextColor = if (isDark) Color(0xFFA0A0B2) else Color(0xFF6B6B80)
+    val inputBgColor = if (isDark) Color(0xFF242430) else Color(0xFFF2F2F8)
+    val primaryColor = MaterialTheme.colorScheme.primary
+
+    LaunchedEffect(Unit) {
+        try {
+            focusRequester.requestFocus()
+        } catch (_: Exception) {}
+    }
+
+    Dialog(
         onDismissRequest = {},
-        title = {
-            Text(
-                text = "Welcome! 👋",
-                style = MaterialTheme.typography.headlineSmall
-            )
-        },
-        text = {
-            Column(
+        properties = DialogProperties(
+            dismissOnBackPress = false,
+            dismissOnClickOutside = false,
+            usePlatformDefaultWidth = false
+        )
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 24.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Card(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = 8.dp),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
+                    .clip(RoundedCornerShape(28.dp)),
+                colors = CardDefaults.cardColors(containerColor = dialogBgColor),
+                elevation = CardDefaults.cardElevation(defaultElevation = 12.dp),
+                shape = RoundedCornerShape(28.dp)
             ) {
-                Text(
-                    text = "What should I call you?",
-                    style = MaterialTheme.typography.bodyLarge,
-                    modifier = Modifier.padding(bottom = 16.dp)
-                )
-
-                OutlinedTextField(
-                    value = nameInput,
-                    onValueChange = {
-                        if (it.text.length <= 9) {
-                            nameInput = it
-                        }
-                    },
-                    label = { Text(stringResource(R.string.your_name)) },
-                    placeholder = { Text(stringResource(R.string.max_9_letters)) },
-                    singleLine = true,
+                Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .focusRequester(focusRequester),
-                    keyboardOptions = KeyboardOptions(
-                        imeAction = ImeAction.Done
-                    ),
-                    keyboardActions = KeyboardActions(
-                        onDone = {
-                            if (isNameValid) {
-                                keyboardController?.hide()
-                                onNameConfirmed(nameInput.text)
-                            }
-                        }
-                    ),
-                    isError = nameInput.text.isNotEmpty() && !isNameValid,
-                    supportingText = {
-                        if (nameInput.text.isNotEmpty() && !isNameValid) {
-                            Text(
-                                text = "Name must be 1-9 characters",
-                                color = MaterialTheme.colorScheme.error,
-                                style = MaterialTheme.typography.bodySmall
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    // Logo Icon Badge
+                    Box(
+                        modifier = Modifier
+                            .size(64.dp)
+                            .clip(CircleShape)
+                            .background(
+                                Brush.linearGradient(
+                                    listOf(
+                                        primaryColor.copy(alpha = 0.25f),
+                                        primaryColor.copy(alpha = 0.08f)
+                                    )
+                                )
                             )
-                        }
+                            .border(1.5.dp, primaryColor.copy(alpha = 0.35f), CircleShape),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.airbeats_monochrome),
+                            contentDescription = null,
+                            tint = primaryColor,
+                            modifier = Modifier.size(36.dp)
+                        )
                     }
-                )
 
-                Spacer(modifier = Modifier.height(4.dp))
+                    Spacer(modifier = Modifier.height(18.dp))
 
-                Text(
-                    text = "${nameInput.text.length}/9",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                    // Title
+                    Text(
+                        text = "Welcome to AirBeats!",
+                        fontSize = 20.sp,
+                        fontWeight = FontWeight.Bold,
+                        color = textColor,
+                        textAlign = TextAlign.Center
+                    )
+
+                    Spacer(modifier = Modifier.height(6.dp))
+
+                    // Subtitle
+                    Text(
+                        text = "What should we call you? Enter your name or nickname to personalize your experience.",
+                        fontSize = 14.sp,
+                        color = subTextColor,
+                        textAlign = TextAlign.Center,
+                        lineHeight = 19.sp
+                    )
+
+                    Spacer(modifier = Modifier.height(22.dp))
+
+                    // High Contrast Text Field
+                    OutlinedTextField(
+                        value = nameInput,
+                        onValueChange = {
+                            if (it.text.length <= 16) {
+                                nameInput = it
+                            }
+                        },
+                        label = {
+                            Text(
+                                text = "Your Name",
+                                color = if (nameInput.text.isNotEmpty()) primaryColor else subTextColor,
+                                fontWeight = FontWeight.Medium
+                            )
+                        },
+                        placeholder = {
+                            Text(
+                                text = "e.g. Alex, Venom...",
+                                color = subTextColor.copy(alpha = 0.7f)
+                            )
+                        },
+                        singleLine = true,
+                        textStyle = TextStyle(
+                            color = textColor,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.SemiBold
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .focusRequester(focusRequester),
+                        shape = RoundedCornerShape(14.dp),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = textColor,
+                            unfocusedTextColor = textColor,
+                            focusedContainerColor = inputBgColor,
+                            unfocusedContainerColor = inputBgColor,
+                            focusedBorderColor = primaryColor,
+                            unfocusedBorderColor = primaryColor.copy(alpha = 0.4f),
+                            cursorColor = primaryColor
+                        ),
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.Words,
+                            imeAction = ImeAction.Done
+                        ),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                if (isNameValid) {
+                                    keyboardController?.hide()
+                                    onNameConfirmed(trimmedName)
+                                }
+                            }
+                        )
+                    )
+
+                    Spacer(modifier = Modifier.height(6.dp))
+
+                    // Character counter
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        Text(
+                            text = "${nameInput.text.length} / 16",
+                            fontSize = 12.sp,
+                            color = subTextColor
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    // Get Started Button
+                    Button(
+                        onClick = {
+                            keyboardController?.hide()
+                            onNameConfirmed(trimmedName)
+                        },
+                        enabled = isNameValid,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp),
+                        shape = RoundedCornerShape(14.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = primaryColor,
+                            contentColor = Color.White,
+                            disabledContainerColor = primaryColor.copy(alpha = 0.35f),
+                            disabledContentColor = Color.White.copy(alpha = 0.6f)
+                        ),
+                        elevation = ButtonDefaults.buttonElevation(
+                            defaultElevation = 4.dp,
+                            pressedElevation = 1.dp
+                        )
+                    ) {
+                        Text(
+                            text = "Get Started",
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
             }
-        },
-        confirmButton = {
-            Button(
-                onClick = {
-                    keyboardController?.hide()
-                    onNameConfirmed(nameInput.text)
-                },
-                enabled = isNameValid,
-                shape = RoundedCornerShape(8.dp)
-            ) {
-                Text(stringResource(R.string.continue_button))
-            }
-        },
-        shape = RoundedCornerShape(16.dp)
-    )
+        }
+    }
 }

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/onboarding/GuestProfileSetupScreen.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/onboarding/GuestProfileSetupScreen.kt
@@ -1,21 +1,36 @@
 package com.darkxvenom.airbeats.ui.screens.onboarding
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import com.darkxvenom.airbeats.ui.component.NamePreferenceManager
+import com.darkxvenom.airbeats.ui.component.AvatarSelector
 import com.darkxvenom.airbeats.R
 import kotlinx.coroutines.launch
 
@@ -26,87 +41,208 @@ fun GuestProfileSetupScreen(navController: NavController) {
     val namePrefManager = remember { NamePreferenceManager(context) }
     var name by remember { mutableStateOf("") }
     val coroutineScope = rememberCoroutineScope()
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    val isDark = isSystemInDarkTheme()
+    val bgColor = if (isDark) Color(0xFF0F0F14) else Color(0xFFF6F7FB)
+    val cardBg = if (isDark) Color(0xFF181822) else Color(0xFFFFFFFF)
+    val textColor = if (isDark) Color(0xFFEEEEF2) else Color(0xFF111118)
+    val subTextColor = if (isDark) Color(0xFFA0A0B2) else Color(0xFF6B6B80)
+    val inputBg = if (isDark) Color(0xFF22222E) else Color(0xFFEEEEF4)
+    val primaryColor = MaterialTheme.colorScheme.primary
+
+    val trimmedName = name.trim()
+    val isNameValid = trimmedName.isNotEmpty() && trimmedName.length <= 16
 
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .background(
-                Brush.verticalGradient(
-                    colors = listOf(
-                        Color(0xFFE3F2FD),
-                        Color(0xFFBBDEFB),
-                        Color(0xFF90CAF9)
-                    )
-                )
-            )
+            .background(bgColor)
+            .statusBarsPadding()
+            .navigationBarsPadding(),
+        contentAlignment = Alignment.Center
     ) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(24.dp),
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp, vertical = 24.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
-            Text(
-                text = stringResource(R.string.set_up_profile),
-                color = Color(0xFF111111),
-                fontSize = 28.sp,
-                fontWeight = FontWeight.Bold,
-                modifier = Modifier.padding(bottom = 32.dp)
-            )
-
-            com.darkxvenom.airbeats.ui.component.AvatarSelector()
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            OutlinedTextField(
-                value = name,
-                onValueChange = { name = it },
-                label = { Text(stringResource(R.string.what_should_we_call_you), color = Color(0xFF333333)) },
-                colors = TextFieldDefaults.colors(
-                    focusedTextColor = Color.Black,
-                    unfocusedTextColor = Color.DarkGray,
-                    focusedIndicatorColor = Color(0xFF1976D2),
-                    unfocusedIndicatorColor = Color.Gray,
-                    cursorColor = Color(0xFF1976D2),
-                    focusedContainerColor = Color.White.copy(alpha = 0.5f),
-                    unfocusedContainerColor = Color.White.copy(alpha = 0.5f)
-                ),
-                singleLine = true,
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            Spacer(modifier = Modifier.height(32.dp))
-
-            Button(
-                onClick = {
-                    if (name.isNotBlank()) {
-                        coroutineScope.launch {
-                            namePrefManager.saveUserName(name)
-                            navController.navigate("home") { // Needs to pop back stack
-                                popUpTo("onboarding") { inclusive = true }
-                            }
-                        }
-                    }
-                },
-                enabled = name.isNotBlank(),
-                colors = ButtonDefaults.buttonColors(
-                    containerColor = Color(0xFF1976D2),
-                    contentColor = Color.White,
-                    disabledContainerColor = Color.LightGray,
-                    disabledContentColor = Color.DarkGray
-                ),
-                shape = RoundedCornerShape(24.dp),
-                elevation = ButtonDefaults.buttonElevation(defaultElevation = 2.dp),
+            Card(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(56.dp)
+                    .clip(RoundedCornerShape(32.dp)),
+                colors = CardDefaults.cardColors(containerColor = cardBg),
+                elevation = CardDefaults.cardElevation(defaultElevation = 8.dp),
+                shape = RoundedCornerShape(32.dp)
             ) {
-                Text(
-                    text = "Continue",
-                    fontSize = 16.sp,
-                    fontWeight = FontWeight.SemiBold
-                )
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    // Header Logo Badge
+                    Box(
+                        modifier = Modifier
+                            .size(60.dp)
+                            .clip(CircleShape)
+                            .background(
+                                Brush.linearGradient(
+                                    listOf(
+                                        primaryColor.copy(alpha = 0.25f),
+                                        primaryColor.copy(alpha = 0.08f)
+                                    )
+                                )
+                            )
+                            .border(1.5.dp, primaryColor.copy(alpha = 0.35f), CircleShape),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        Icon(
+                            painter = painterResource(R.drawable.airbeats_monochrome),
+                            contentDescription = null,
+                            tint = primaryColor,
+                            modifier = Modifier.size(34.dp)
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text(
+                        text = stringResource(R.string.set_up_profile),
+                        color = textColor,
+                        fontSize = 24.sp,
+                        fontWeight = FontWeight.Bold,
+                        textAlign = TextAlign.Center
+                    )
+
+                    Spacer(modifier = Modifier.height(4.dp))
+
+                    Text(
+                        text = "Customize your avatar and choose a name to get started with AirBeats.",
+                        color = subTextColor,
+                        fontSize = 14.sp,
+                        textAlign = TextAlign.Center,
+                        lineHeight = 19.sp
+                    )
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    // Avatar Selector
+                    AvatarSelector()
+
+                    Spacer(modifier = Modifier.height(20.dp))
+
+                    // Name Input Field
+                    OutlinedTextField(
+                        value = name,
+                        onValueChange = {
+                            if (it.length <= 16) {
+                                name = it
+                            }
+                        },
+                        label = {
+                            Text(
+                                text = stringResource(R.string.what_should_we_call_you),
+                                color = if (name.isNotEmpty()) primaryColor else subTextColor,
+                                fontWeight = FontWeight.Medium
+                            )
+                        },
+                        placeholder = {
+                            Text(
+                                text = "e.g. Venom",
+                                color = subTextColor.copy(alpha = 0.6f)
+                            )
+                        },
+                        singleLine = true,
+                        textStyle = TextStyle(
+                            color = textColor,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.SemiBold
+                        ),
+                        modifier = Modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(16.dp),
+                        colors = OutlinedTextFieldDefaults.colors(
+                            focusedTextColor = textColor,
+                            unfocusedTextColor = textColor,
+                            focusedContainerColor = inputBg,
+                            unfocusedContainerColor = inputBg,
+                            focusedBorderColor = primaryColor,
+                            unfocusedBorderColor = primaryColor.copy(alpha = 0.4f),
+                            cursorColor = primaryColor
+                        ),
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.Words,
+                            imeAction = ImeAction.Done
+                        ),
+                        keyboardActions = KeyboardActions(
+                            onDone = {
+                                if (isNameValid) {
+                                    keyboardController?.hide()
+                                    coroutineScope.launch {
+                                        namePrefManager.saveUserName(trimmedName)
+                                        navController.navigate("home") {
+                                            popUpTo("onboarding") { inclusive = true }
+                                        }
+                                    }
+                                }
+                            }
+                        )
+                    )
+
+                    Spacer(modifier = Modifier.height(6.dp))
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.End
+                    ) {
+                        Text(
+                            text = "${name.length} / 16",
+                            fontSize = 12.sp,
+                            color = subTextColor
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(24.dp))
+
+                    // Continue Button
+                    Button(
+                        onClick = {
+                            if (isNameValid) {
+                                keyboardController?.hide()
+                                coroutineScope.launch {
+                                    namePrefManager.saveUserName(trimmedName)
+                                    navController.navigate("home") {
+                                        popUpTo("onboarding") { inclusive = true }
+                                    }
+                                }
+                            }
+                        },
+                        enabled = isNameValid,
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = primaryColor,
+                            contentColor = Color.White,
+                            disabledContainerColor = primaryColor.copy(alpha = 0.35f),
+                            disabledContentColor = Color.White.copy(alpha = 0.6f)
+                        ),
+                        shape = RoundedCornerShape(16.dp),
+                        elevation = ButtonDefaults.buttonElevation(
+                            defaultElevation = 4.dp,
+                            pressedElevation = 1.dp
+                        ),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(52.dp)
+                    ) {
+                        Text(
+                            text = "Continue",
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.Bold
+                        )
+                    }
+                }
             }
         }
     }

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/VoiceAssistantSettings.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/VoiceAssistantSettings.kt
@@ -1,0 +1,601 @@
+package com.darkxvenom.airbeats.ui.screens.settings
+
+import android.Manifest
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
+import android.os.PowerManager
+import android.provider.Settings
+import android.widget.Toast
+import com.darkxvenom.airbeats.voice.VoiceAssistantActionExecutor
+import com.darkxvenom.airbeats.voice.VoiceAssistantManager
+import com.darkxvenom.airbeats.voice.VoiceCommand
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
+import androidx.navigation.NavController
+import com.darkxvenom.airbeats.R
+import com.darkxvenom.airbeats.constants.EnableVoiceAssistantKey
+import com.darkxvenom.airbeats.constants.VoiceAssistantAutoStartOnBootKey
+import com.darkxvenom.airbeats.constants.VoiceAssistantDirectCommandsKey
+import com.darkxvenom.airbeats.constants.VoiceAssistantTtsFeedbackKey
+import com.darkxvenom.airbeats.ui.component.PreferenceGroupTitle
+import com.darkxvenom.airbeats.ui.component.SettingsGeneralCategory
+import com.darkxvenom.airbeats.ui.component.SettingsPage
+import com.darkxvenom.airbeats.ui.component.SwitchPreference
+import com.darkxvenom.airbeats.utils.rememberPreference
+import com.darkxvenom.airbeats.voice.VoiceAssistantService
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun VoiceAssistantSettings(
+    navController: NavController,
+    scrollBehavior: TopAppBarScrollBehavior,
+) {
+    val context = LocalContext.current
+
+    val (enableVoiceAssistant, onEnableVoiceAssistantChange) = rememberPreference(
+        EnableVoiceAssistantKey,
+        defaultValue = false
+    )
+    val (directCommands, onDirectCommandsChange) = rememberPreference(
+        VoiceAssistantDirectCommandsKey,
+        defaultValue = false
+    )
+    val (ttsFeedback, onTtsFeedbackChange) = rememberPreference(
+        VoiceAssistantTtsFeedbackKey,
+        defaultValue = true
+    )
+    val (autoStartOnBoot, onAutoStartOnBootChange) = rememberPreference(
+        VoiceAssistantAutoStartOnBootKey,
+        defaultValue = false
+    )
+
+    var hasMicPermission by remember {
+        mutableStateOf(
+            ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.RECORD_AUDIO
+            ) == PackageManager.PERMISSION_GRANTED
+        )
+    }
+
+    val isIgnoringBatteryOptimizations by remember {
+        mutableStateOf(
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+                powerManager.isIgnoringBatteryOptimizations(context.packageName)
+            } else {
+                true
+            }
+        )
+    }
+
+    val micPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        hasMicPermission = isGranted
+        if (isGranted) {
+            onEnableVoiceAssistantChange(true)
+            VoiceAssistantService.start(context)
+        } else {
+            Toast.makeText(context, R.string.voice_permission_required, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    var hasOverlayPermission by remember {
+        mutableStateOf(
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                Settings.canDrawOverlays(context)
+            } else {
+                true
+            }
+        )
+    }
+
+    val isServiceRunning by VoiceAssistantService.isServiceRunning.collectAsState()
+
+    SettingsPage(
+        title = stringResource(R.string.voice_assistant),
+        navController = navController,
+        scrollBehavior = scrollBehavior
+    ) {
+        // Master switch category
+        SettingsGeneralCategory(
+            title = stringResource(R.string.voice_assistant),
+            items = listOf(
+                {
+                    SwitchPreference(
+                        title = { Text(stringResource(R.string.enable_voice_assistant)) },
+                        description = stringResource(R.string.enable_voice_assistant_desc),
+                        icon = {
+                            Icon(
+                                painter = painterResource(R.drawable.mic),
+                                contentDescription = null
+                            )
+                        },
+                        checked = enableVoiceAssistant,
+                        onCheckedChange = { isChecked ->
+                            if (isChecked) {
+                                if (!hasMicPermission) {
+                                    micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                                } else {
+                                    onEnableVoiceAssistantChange(true)
+                                    VoiceAssistantService.start(context)
+                                }
+                            } else {
+                                onEnableVoiceAssistantChange(false)
+                                VoiceAssistantService.stop(context)
+                            }
+                        }
+                    )
+                }
+            )
+        )
+
+        // Status & Permissions Banner
+        if (!hasMicPermission || !isIgnoringBatteryOptimizations || !hasOverlayPermission) {
+            PreferenceGroupTitle(title = "Permissions & Enhancements")
+
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                    .clip(RoundedCornerShape(16.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp)
+            ) {
+                if (!hasMicPermission) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.voice_grant_mic_permission),
+                                fontWeight = FontWeight.Bold,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Text(
+                                text = stringResource(R.string.voice_mic_permission_desc),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        Button(
+                            onClick = { micPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO) },
+                            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+                        ) {
+                            Text("Grant", fontSize = 12.sp)
+                        }
+                    }
+                }
+
+                if (!hasOverlayPermission && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = "✨ AirBeats Voice Aura HUD",
+                                fontWeight = FontWeight.Bold,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Text(
+                                text = "Displays an animated glow & live speech sheet at the bottom of your phone when AirBeats listens in the background.",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        Button(
+                            onClick = {
+                                try {
+                                    val intent = Intent(
+                                        Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
+                                        Uri.parse("package:${context.packageName}")
+                                    )
+                                    context.startActivity(intent)
+                                } catch (_: Exception) {
+                                    Toast.makeText(context, "Open Settings -> Apps -> AirBeats -> Display over other apps", Toast.LENGTH_LONG).show()
+                                }
+                            },
+                            colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.primary)
+                        ) {
+                            Text("Enable", fontSize = 12.sp)
+                        }
+                    }
+                }
+
+                if (!isIgnoringBatteryOptimizations && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = stringResource(R.string.voice_disable_battery_opt),
+                                fontWeight = FontWeight.Bold,
+                                style = MaterialTheme.typography.bodyMedium
+                            )
+                            Text(
+                                text = stringResource(R.string.voice_disable_battery_opt_desc),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                        Spacer(Modifier.width(8.dp))
+                        OutlinedButton(
+                            onClick = {
+                                try {
+                                    val intent = Intent(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS).apply {
+                                        data = Uri.parse("package:${context.packageName}")
+                                    }
+                                    context.startActivity(intent)
+                                } catch (e: Exception) {
+                                    Toast.makeText(context, "Open Settings -> Apps -> AirBeats -> Battery -> Unrestricted", Toast.LENGTH_LONG).show()
+                                }
+                            }
+                        ) {
+                            Text("Disable", fontSize = 12.sp)
+                        }
+                    }
+                }
+            }
+        }
+
+        // Assistant Configuration
+        AnimatedVisibility(visible = enableVoiceAssistant) {
+            Column {
+                SettingsGeneralCategory(
+                    title = "Configuration",
+                    items = listOf(
+                        {
+                            SwitchPreference(
+                                title = { Text(stringResource(R.string.voice_direct_commands)) },
+                                description = stringResource(R.string.voice_direct_commands_desc),
+                                icon = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.mic),
+                                        contentDescription = null
+                                    )
+                                },
+                                checked = directCommands,
+                                onCheckedChange = onDirectCommandsChange
+                            )
+                        },
+                        {
+                            SwitchPreference(
+                                title = { Text(stringResource(R.string.voice_tts_feedback)) },
+                                description = stringResource(R.string.voice_tts_feedback_desc),
+                                icon = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.volume_up),
+                                        contentDescription = null
+                                    )
+                                },
+                                checked = ttsFeedback,
+                                onCheckedChange = onTtsFeedbackChange
+                            )
+                        },
+                        {
+                            SwitchPreference(
+                                title = { Text(stringResource(R.string.voice_auto_start_boot)) },
+                                description = stringResource(R.string.voice_auto_start_boot_desc),
+                                icon = {
+                                    Icon(
+                                        painter = painterResource(R.drawable.sync),
+                                        contentDescription = null
+                                    )
+                                },
+                                checked = autoStartOnBoot,
+                                onCheckedChange = onAutoStartOnBootChange
+                            )
+                        }
+                    )
+                )
+
+
+                // Interactive Live Test Card
+                PreferenceGroupTitle(title = stringResource(R.string.voice_test_assistant))
+                VoiceTestCard()
+            }
+        }
+
+        // Commands Guide
+        PreferenceGroupTitle(title = stringResource(R.string.voice_commands_guide))
+
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .clip(RoundedCornerShape(16.dp))
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f))
+                .padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp)
+        ) {
+            CommandGuideRow(
+                phrase = "\"Hi AirBeats, play Starboy\"",
+                action = "Plays the requested song or artist"
+            )
+            CommandGuideRow(
+                phrase = "\"Hi AirBeats, pause\" / \"Resume\"",
+                action = "Pauses or resumes music playback"
+            )
+            CommandGuideRow(
+                phrase = "\"Hi AirBeats, next song\" / \"Skip\"",
+                action = "Skips to the next track in queue"
+            )
+            CommandGuideRow(
+                phrase = "\"Hi AirBeats, previous track\"",
+                action = "Plays the previous track"
+            )
+            CommandGuideRow(
+                phrase = "\"Hi AirBeats, like this song\"",
+                action = "Toggles favorite / like status"
+            )
+            CommandGuideRow(
+                phrase = "\"Hi AirBeats, volume up\" / \"Volume 80%\"",
+                action = "Controls player volume level"
+            )
+            CommandGuideRow(
+                phrase = "\"Hi AirBeats, start radio\"",
+                action = "Starts radio based on current song"
+            )
+        }
+    }
+}
+
+@Composable
+private fun CommandGuideRow(phrase: String, action: String) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text = phrase,
+            style = MaterialTheme.typography.bodyMedium,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary
+        )
+        Text(
+            text = action,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+    }
+}
+
+@Composable
+private fun VoiceTestCard() {
+    val context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
+    val playerConnection = com.darkxvenom.airbeats.playback.PlayerConnection.instance
+    var isTesting by remember { mutableStateOf(false) }
+    var actionStatus by remember { mutableStateOf("") }
+
+    val actionExecutor = remember {
+        VoiceAssistantActionExecutor(
+            context = context,
+            scope = coroutineScope,
+            getMusicService = { playerConnection?.service }
+        )
+    }
+
+    val testManager = remember {
+        VoiceAssistantManager(context) { command, text ->
+            when (command) {
+                is VoiceCommand.PlayGenericMusic -> {
+                    actionStatus = "Loading recommended music..."
+                }
+                is VoiceCommand.PlayCachedSongs -> {
+                    actionStatus = "Loading and playing cached library songs..."
+                }
+                is VoiceCommand.PlayLikedSongs -> {
+                    actionStatus = "Loading and playing liked songs..."
+                }
+                is VoiceCommand.PlaySong -> {
+                    actionStatus = "Searching and playing: \"${command.query}\"..."
+                }
+                is VoiceCommand.Pause -> {
+                    actionStatus = "Music paused"
+                }
+                is VoiceCommand.Resume -> {
+                    actionStatus = "Music resumed"
+                }
+                is VoiceCommand.NextTrack -> {
+                    actionStatus = "Skipping to next song"
+                }
+                is VoiceCommand.PreviousTrack -> {
+                    actionStatus = "Playing previous song"
+                }
+                is VoiceCommand.ToggleLike -> {
+                    actionStatus = "Toggled favorite"
+                }
+                is VoiceCommand.StartRadio -> {
+                    actionStatus = "Starting radio station"
+                }
+                is VoiceCommand.VolumeUp -> {
+                    actionStatus = "Volume increased"
+                }
+                is VoiceCommand.VolumeDown -> {
+                    actionStatus = "Volume decreased"
+                }
+                is VoiceCommand.SetVolume -> {
+                    actionStatus = "Volume set to ${command.levelPercent}%"
+                }
+                is VoiceCommand.Mute -> {
+                    actionStatus = "Muted"
+                }
+                is VoiceCommand.Unmute -> {
+                    actionStatus = "Unmuted"
+                }
+                is VoiceCommand.Unknown -> {
+                    actionStatus = "Heard: \"$text\" (say 'play [song]' or song name)"
+                }
+            }
+            actionExecutor.execute(command)
+        }
+    }
+
+    val liveSpokenText by testManager.lastRecognizedText.collectAsState()
+    val isMicListening by testManager.isListening.collectAsState()
+    val audioRms by testManager.audioRms.collectAsState()
+
+    DisposableEffect(Unit) {
+        onDispose {
+            testManager.destroy()
+            actionExecutor.release()
+        }
+    }
+
+    val infiniteTransition = rememberInfiniteTransition(label = "pulse")
+    val pulseScale by infiniteTransition.animateFloat(
+        initialValue = 1.0f,
+        targetValue = if (isTesting && isMicListening) 1.25f else 1.0f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(600, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse
+        ),
+        label = "scale"
+    )
+
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        shape = RoundedCornerShape(16.dp),
+        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+    ) {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(68.dp)
+                    .scale(pulseScale)
+                    .clip(CircleShape)
+                    .background(
+                        if (isTesting) MaterialTheme.colorScheme.primary
+                        else MaterialTheme.colorScheme.primaryContainer
+                    )
+                    .clickable {
+                        isTesting = !isTesting
+                        if (isTesting) {
+                            actionStatus = "Listening... say \"Hi AirBeats play [song]\" or just song name"
+                            testManager.start(requireWakeWord = false)
+                        } else {
+                            testManager.stop()
+                            actionStatus = ""
+                        }
+                    },
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.mic),
+                    contentDescription = null,
+                    tint = if (isTesting) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onPrimaryContainer,
+                    modifier = Modifier.size(34.dp)
+                )
+            }
+
+            Text(
+                text = if (isTesting) "Tap mic to stop test" else "Tap mic to test live voice & playback",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium
+            )
+
+            // Live speech display (shows words live as you speak)
+            if (isTesting && !liveSpokenText.isNullOrBlank()) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(12.dp))
+                        .background(MaterialTheme.colorScheme.background.copy(alpha = 0.7f))
+                        .padding(12.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = "🗣️ Spoken words:",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(Modifier.height(4.dp))
+                    Text(
+                        text = "\"$liveSpokenText\"",
+                        style = MaterialTheme.typography.bodyLarge,
+                        fontWeight = FontWeight.Bold,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+            }
+
+            // Action status & feedback
+            if (actionStatus.isNotBlank()) {
+                Text(
+                    text = actionStatus,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.secondary,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceAssistantActionExecutor.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceAssistantActionExecutor.kt
@@ -1,0 +1,637 @@
+package com.darkxvenom.airbeats.voice
+
+import android.content.Context
+import android.content.Intent
+import android.media.AudioManager
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import android.os.Handler
+import android.os.Looper
+import android.speech.tts.TextToSpeech
+import android.widget.Toast
+import com.darkxvenom.airbeats.App
+import com.darkxvenom.airbeats.R
+import com.darkxvenom.airbeats.constants.HideExplicitKey
+import com.darkxvenom.airbeats.constants.MusicProviderKey
+import com.darkxvenom.airbeats.constants.SongSortType
+import com.darkxvenom.airbeats.constants.VoiceAssistantTtsFeedbackKey
+import com.darkxvenom.airbeats.db.entities.Song
+import com.darkxvenom.airbeats.extensions.toMediaItem
+import com.darkxvenom.airbeats.innertube.YouTube
+import com.darkxvenom.airbeats.innertube.models.SongItem
+import com.darkxvenom.airbeats.innertube.models.WatchEndpoint
+import com.darkxvenom.airbeats.innertube.models.filterExplicit
+import com.darkxvenom.airbeats.models.toMediaMetadata
+import com.darkxvenom.airbeats.playback.MusicService
+import com.darkxvenom.airbeats.playback.PlayerConnection
+import com.darkxvenom.airbeats.playback.queues.ListQueue
+import com.darkxvenom.airbeats.playback.queues.YouTubeQueue
+import com.darkxvenom.airbeats.utils.dataStore
+import com.darkxvenom.airbeats.utils.get
+import com.darkxvenom.airbeats.utils.reportException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+import java.util.Locale
+
+class VoiceAssistantActionExecutor(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    private val getMusicService: () -> MusicService?,
+    private val overlayManager: VoiceAssistantOverlayManager? = null
+) : TextToSpeech.OnInitListener {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private var tts: TextToSpeech? = null
+    private var isTtsReady = false
+
+    init {
+        try {
+            tts = TextToSpeech(context.applicationContext, this)
+        } catch (e: Exception) {
+            Timber.e(e, "Failed to initialize TextToSpeech")
+        }
+    }
+
+    override fun onInit(status: Int) {
+        if (status == TextToSpeech.SUCCESS) {
+            tts?.language = Locale.getDefault()
+            isTtsReady = true
+        } else {
+            Timber.w("TextToSpeech initialization failed with status $status")
+        }
+    }
+
+    fun showToast(message: String, iconResId: Int = R.drawable.music_note) {
+        overlayManager?.showActionResult(message, iconResId)
+        mainHandler.post {
+            try {
+                Toast.makeText(context, message, Toast.LENGTH_SHORT).show()
+            } catch (_: Exception) {}
+        }
+    }
+
+    fun speak(text: String) {
+        scope.launch {
+            val ttsEnabled = context.dataStore.get(VoiceAssistantTtsFeedbackKey, true)
+            if (ttsEnabled && isTtsReady && tts != null) {
+                tts?.speak(text, TextToSpeech.QUEUE_FLUSH, null, "airbeats_voice_feedback")
+            }
+        }
+    }
+
+    private fun isNetworkAvailable(): Boolean {
+        return try {
+            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+            val network = connectivityManager?.activeNetwork ?: return false
+            val capabilities = connectivityManager.getNetworkCapabilities(network) ?: return false
+            capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun applyVolume(levelPercent: Int) {
+        val targetRatio = (levelPercent / 100f).coerceIn(0f, 1f)
+        val service = ensureMusicService()
+        if (service != null) {
+            service.playerVolume.value = targetRatio
+            service.player.volume = targetRatio
+        } else {
+            PlayerConnection.instance?.let {
+                it.service.playerVolume.value = targetRatio
+                it.service.player.volume = targetRatio
+            }
+        }
+
+        try {
+            val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+            val maxVol = audioManager?.getStreamMaxVolume(AudioManager.STREAM_MUSIC) ?: 100
+            val targetSystemVol = (targetRatio * maxVol).toInt().coerceIn(0, maxVol)
+            audioManager?.setStreamVolume(AudioManager.STREAM_MUSIC, targetSystemVol, 0)
+        } catch (_: Exception) {}
+
+        showToast("Volume: $levelPercent%", if (levelPercent == 0) R.drawable.volume_off else R.drawable.volume_up)
+    }
+
+    fun execute(command: VoiceCommand) {
+        Timber.d("Executing voice command: %s", command)
+
+        when (command) {
+            is VoiceCommand.PlayGenericMusic -> {
+                showToast("Loading music...", R.drawable.music_note)
+                handlePlayGenericMusic()
+            }
+            is VoiceCommand.PlayCachedSongs -> {
+                showToast("Loading library songs...", R.drawable.library_music)
+                handlePlayCachedSongs()
+            }
+            is VoiceCommand.PlayLikedSongs -> {
+                showToast("Loading liked songs...", R.drawable.favorite)
+                handlePlayLikedSongs()
+            }
+            is VoiceCommand.PlaySong -> {
+                showToast("Searching: \"${command.query}\"", R.drawable.search)
+                handlePlaySong(command.query)
+            }
+            is VoiceCommand.Pause -> {
+                scope.launch(Dispatchers.Main) {
+                    showToast("Paused", R.drawable.pause)
+                    val service = ensureMusicService()
+                    service?.player?.pause()
+                }
+            }
+            is VoiceCommand.Resume -> {
+                scope.launch(Dispatchers.Main) {
+                    showToast("Resumed", R.drawable.play)
+                    val service = ensureMusicService()
+                    service?.player?.play()
+                }
+            }
+            is VoiceCommand.NextTrack -> {
+                scope.launch(Dispatchers.Main) {
+                    showToast("Next track", R.drawable.skip_next)
+                    val service = ensureMusicService()
+                    service?.player?.let { player ->
+                        if (player.hasNextMediaItem()) {
+                            player.seekToNext()
+                            player.prepare()
+                            player.playWhenReady = true
+                            player.play()
+                        }
+                    }
+                }
+            }
+            is VoiceCommand.PreviousTrack -> {
+                scope.launch(Dispatchers.Main) {
+                    showToast("Previous track", R.drawable.skip_previous)
+                    val service = ensureMusicService()
+                    service?.player?.let { player ->
+                        if (player.hasPreviousMediaItem()) {
+                            player.seekToPreviousMediaItem()
+                            player.prepare()
+                            player.playWhenReady = true
+                            player.play()
+                        } else {
+                            player.seekTo(0)
+                            player.prepare()
+                            player.playWhenReady = true
+                            player.play()
+                        }
+                    }
+                }
+            }
+            is VoiceCommand.ToggleLike -> {
+                scope.launch(Dispatchers.Main) {
+                    showToast("Added to favorites", R.drawable.favorite)
+                    val service = ensureMusicService()
+                    service?.toggleLike()
+                }
+            }
+            is VoiceCommand.StartRadio -> {
+                scope.launch(Dispatchers.Main) {
+                    showToast("Starting radio...", R.drawable.radio)
+                    val service = ensureMusicService()
+                    service?.startRadioSeamlessly()
+                }
+            }
+            is VoiceCommand.VolumeUp -> {
+                scope.launch(Dispatchers.Main) {
+                    val service = ensureMusicService()
+                    val currentRatio = service?.playerVolume?.value ?: service?.player?.volume ?: 0.5f
+                    val newPercent = ((currentRatio + 0.15f) * 100).toInt().coerceIn(0, 100)
+                    applyVolume(newPercent)
+                }
+            }
+            is VoiceCommand.VolumeDown -> {
+                scope.launch(Dispatchers.Main) {
+                    val service = ensureMusicService()
+                    val currentRatio = service?.playerVolume?.value ?: service?.player?.volume ?: 0.5f
+                    val newPercent = ((currentRatio - 0.15f) * 100).toInt().coerceIn(0, 100)
+                    applyVolume(newPercent)
+                }
+            }
+            is VoiceCommand.SetVolume -> {
+                scope.launch(Dispatchers.Main) {
+                    applyVolume(command.levelPercent)
+                }
+            }
+            is VoiceCommand.Mute -> {
+                scope.launch(Dispatchers.Main) {
+                    applyVolume(0)
+                }
+            }
+            is VoiceCommand.Unmute -> {
+                scope.launch(Dispatchers.Main) {
+                    applyVolume(100)
+                }
+            }
+            is VoiceCommand.Unknown -> {
+                Timber.d("Unknown voice command: %s", command.rawText)
+            }
+        }
+    }
+
+    private suspend fun getAllLocalCachedSongs(): List<Song> = withContext(Dispatchers.IO) {
+        try {
+            val database = App.instance.database
+            // 1. Try allSongs() which contains every cached & played song stored in the app
+            val all = database.allSongs().firstOrNull()
+            if (!all.isNullOrEmpty()) return@withContext all
+
+            // 2. Try songs in library
+            val library = database.songs(SongSortType.CREATE_DATE, true).firstOrNull()
+            if (!library.isNullOrEmpty()) return@withContext library
+
+            // 3. Try liked songs
+            val liked = database.likedSongs(SongSortType.CREATE_DATE, true).firstOrNull()
+            if (!liked.isNullOrEmpty()) return@withContext liked
+
+            emptyList()
+        } catch (e: Exception) {
+            Timber.e(e, "Error querying local cached songs")
+            emptyList()
+        }
+    }
+
+    private fun handlePlayGenericMusic() {
+        scope.launch {
+            try {
+                val isOnline = isNetworkAvailable()
+                if (!isOnline) {
+                    // When offline, immediately play and shuffle songs from the local library
+                    handlePlayCachedSongs()
+                    return@launch
+                }
+
+                // 1. Check user's listening history, liked songs, and library to determine personal taste
+                val database = App.instance.database
+                val userTasteSeeds = withContext(Dispatchers.IO) {
+                    try {
+                        val liked = database.likedSongs(SongSortType.PLAY_TIME, true).firstOrNull() ?: emptyList()
+                        val played = database.songs(SongSortType.PLAY_TIME, true).firstOrNull() ?: emptyList()
+                        val all = database.allSongs().firstOrNull() ?: emptyList()
+                        (liked + played + all).distinctBy { it.id }.filter { it.id.isNotBlank() }
+                    } catch (e: Exception) {
+                        Timber.w(e, "Could not fetch user taste seeds")
+                        emptyList()
+                    }
+                }
+
+                if (userTasteSeeds.isNotEmpty()) {
+                    // Pick a seed song from user favorites to generate personalized endless radio tailored to their taste
+                    val seedSong = userTasteSeeds.take(20).shuffled().first()
+                    val queue = YouTubeQueue.radio(seedSong.toMediaMetadata())
+
+                    withContext(Dispatchers.Main) {
+                        val service = ensureMusicService()
+                        if (service != null) {
+                            service.player.shuffleModeEnabled = true
+                            service.playQueue(queue, playWhenReady = true)
+                            service.player.play()
+                        } else {
+                            PlayerConnection.instance?.let {
+                                it.service.player.shuffleModeEnabled = true
+                                it.playQueue(queue)
+                                it.service.player.play()
+                            }
+                        }
+                        showToast("Playing recommended songs based on your taste")
+                    }
+                    speak("Playing recommended songs based on your taste")
+                    return@launch
+                }
+
+                // 2. If user is brand new with no local history, fetch popular / trending tracks
+                val hideExplicit = context.dataStore.get(HideExplicitKey, false)
+                val searchResult = withContext(Dispatchers.IO) {
+                    YouTube.search("Trending Songs", YouTube.SearchFilter.FILTER_SONG)
+                }
+
+                val songs = searchResult.getOrNull()?.items
+                    ?.filterIsInstance<SongItem>()
+                    ?.filterExplicit(hideExplicit)
+
+                if (!songs.isNullOrEmpty()) {
+                    val shuffled = songs.shuffled()
+                    val first = shuffled.first()
+                    val queue = YouTubeQueue.radio(first.toMediaMetadata())
+
+                    withContext(Dispatchers.Main) {
+                        val service = ensureMusicService()
+                        if (service != null) {
+                            service.player.shuffleModeEnabled = true
+                            service.playQueue(queue, playWhenReady = true)
+                            service.player.play()
+                        } else {
+                            PlayerConnection.instance?.let {
+                                it.service.player.shuffleModeEnabled = true
+                                it.playQueue(queue)
+                                it.service.player.play()
+                            }
+                        }
+                        showToast("Playing recommended songs")
+                    }
+                    speak("Playing recommended songs")
+                } else {
+                    handlePlayCachedSongs()
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error playing recommended music, falling back to library")
+                handlePlayCachedSongs()
+            }
+        }
+    }
+
+    private fun handlePlayCachedSongs() {
+        scope.launch {
+            try {
+                val songs = getAllLocalCachedSongs()
+
+                if (songs.isNotEmpty()) {
+                    val shuffledSongs = songs.shuffled()
+                    val mediaItems = shuffledSongs.map { it.toMediaItem() }
+                    val queue = ListQueue(
+                        title = "Library Songs",
+                        items = mediaItems
+                    )
+
+                    withContext(Dispatchers.Main) {
+                        val service = ensureMusicService()
+                        if (service != null) {
+                            service.player.shuffleModeEnabled = true
+                            service.playQueue(queue, playWhenReady = true)
+                            service.player.play()
+                        } else {
+                            PlayerConnection.instance?.let {
+                                it.service.player.shuffleModeEnabled = true
+                                it.playQueue(queue)
+                                it.service.player.play()
+                            }
+                        }
+                        showToast("Playing songs from your library", R.drawable.library_music)
+                    }
+                    speak("Playing songs from your library")
+                } else {
+                    showToast("No songs found in library", R.drawable.library_music)
+                    speak("No songs found in your library")
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error loading cached songs")
+                showToast("Failed to play library songs", R.drawable.error)
+                speak("Error loading library songs")
+            }
+        }
+    }
+
+    private fun handlePlayLikedSongs() {
+        scope.launch {
+            try {
+                val database = App.instance.database
+                val liked = withContext(Dispatchers.IO) {
+                    try {
+                        database.likedSongs(SongSortType.CREATE_DATE, true).firstOrNull()
+                    } catch (e: Exception) {
+                        Timber.e(e, "Failed to load liked songs")
+                        null
+                    }
+                }
+
+                if (!liked.isNullOrEmpty()) {
+                    val shuffledLiked = liked.shuffled()
+                    val mediaItems = shuffledLiked.map { it.toMediaItem() }
+                    val queue = ListQueue(
+                        title = "Liked Songs",
+                        items = mediaItems
+                    )
+
+                    withContext(Dispatchers.Main) {
+                        val service = ensureMusicService()
+                        if (service != null) {
+                            service.player.shuffleModeEnabled = true
+                            service.playQueue(queue, playWhenReady = true)
+                            service.player.play()
+                        } else {
+                            PlayerConnection.instance?.let {
+                                it.service.player.shuffleModeEnabled = true
+                                it.playQueue(queue)
+                                it.service.player.play()
+                            }
+                        }
+                        showToast("Playing your liked songs", R.drawable.favorite)
+                    }
+                    speak("Playing your liked songs")
+                } else {
+                    showToast("No liked songs found", R.drawable.favorite_border)
+                    speak("No liked songs found")
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error loading liked songs")
+                showToast("Failed to play liked songs", R.drawable.error)
+                speak("Error loading liked songs")
+            }
+        }
+    }
+
+    private suspend fun searchCachedLibrarySong(query: String): Song? = withContext(Dispatchers.IO) {
+        try {
+            val allSongs = getAllLocalCachedSongs()
+            if (allSongs.isEmpty()) return@withContext null
+
+            val cleanQuery = query.lowercase(Locale.ROOT).trim()
+                .replace(Regex("[.,!?;:'\"()\\[\\]\\-_]"), " ")
+                .replace(Regex("\\s+"), " ")
+                .trim()
+
+            // 1. Exact clean match
+            allSongs.firstOrNull { song ->
+                val cleanTitle = song.song.title.lowercase(Locale.ROOT)
+                    .replace(Regex("[.,!?;:'\"()\\[\\]\\-_]"), " ")
+                    .replace(Regex("\\s+"), " ")
+                    .trim()
+                cleanTitle == cleanQuery
+            }
+            // 2. Title contains full query
+            ?: allSongs.firstOrNull { song ->
+                song.song.title.lowercase(Locale.ROOT).contains(cleanQuery)
+            }
+            // 3. Title starts with query
+            ?: allSongs.firstOrNull { song ->
+                song.song.title.lowercase(Locale.ROOT).startsWith(cleanQuery)
+            }
+            // 4. Keyword fuzzy match (every word in query matches song title or artist)
+            ?: allSongs.firstOrNull { song ->
+                val words = cleanQuery.split(" ").filter { it.length >= 2 }
+                val title = song.song.title.lowercase(Locale.ROOT)
+                val artists = song.artists.joinToString(" ") { it.name.lowercase(Locale.ROOT) }
+                words.isNotEmpty() && words.all { title.contains(it) || artists.contains(it) }
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error searching cached songs")
+            null
+        }
+    }
+
+    private suspend fun playLocalCachedSong(song: Song) {
+        val mediaItem = song.toMediaItem()
+        val queue = ListQueue(
+            title = "Cached Song",
+            items = listOf(mediaItem)
+        )
+
+        withContext(Dispatchers.Main) {
+            val service = ensureMusicService()
+            if (service != null) {
+                service.playQueue(queue, playWhenReady = true)
+                service.player.play()
+            } else {
+                PlayerConnection.instance?.let {
+                    it.playQueue(queue)
+                    it.service.player.play()
+                }
+            }
+            showToast("Playing: ${song.song.title}", R.drawable.play)
+        }
+
+        val artistName = song.artists.joinToString { it.name }
+        if (artistName.isNotBlank()) {
+            speak("Playing ${song.song.title} by $artistName")
+        } else {
+            speak("Playing ${song.song.title}")
+        }
+    }
+
+    private fun handlePlaySong(query: String) {
+        scope.launch {
+            try {
+                val isOnline = isNetworkAvailable()
+                var songToPlayOnline: SongItem? = null
+
+                // If offline, immediately search local cached songs
+                if (!isOnline) {
+                    val localSong = searchCachedLibrarySong(query)
+                    if (localSong != null) {
+                        playLocalCachedSong(localSong)
+                        return@launch
+                    } else {
+                        showToast("Offline: \"$query\" not found in cache", R.drawable.search_off)
+                        speak("Song $query was not found")
+                        return@launch
+                    }
+                }
+
+                // If online, search YouTube Music / JioSaavn
+                val hideExplicit = context.dataStore.get(HideExplicitKey, false)
+                val musicProvider = context.dataStore.get(MusicProviderKey, "YT")
+
+                if (musicProvider == "JIOSAAVN") {
+                    try {
+                        val jioResult = com.darkxvenom.airbeats.jiosaavn.JioSaavnApi.searchSongs(query)
+                        songToPlayOnline = jioResult.getOrNull()?.firstOrNull()
+                    } catch (e: Exception) {
+                        Timber.w(e, "JioSaavn search error")
+                    }
+                }
+
+                if (songToPlayOnline == null) {
+                    try {
+                        val searchResult = withContext(Dispatchers.IO) {
+                            YouTube.search(query, YouTube.SearchFilter.FILTER_SONG)
+                        }
+
+                        songToPlayOnline = searchResult.getOrNull()?.items
+                            ?.filterIsInstance<SongItem>()
+                            ?.filterExplicit(hideExplicit)
+                            ?.firstOrNull()
+
+                        if (songToPlayOnline == null) {
+                            val summaryResult = withContext(Dispatchers.IO) {
+                                YouTube.searchSummary(query)
+                            }
+                            songToPlayOnline = summaryResult.getOrNull()?.summaries
+                                ?.flatMap { it.items }
+                                ?.filterIsInstance<SongItem>()
+                                ?.filterExplicit(hideExplicit)
+                                ?.firstOrNull()
+                        }
+                    } catch (e: Exception) {
+                        Timber.w(e, "Online search failed")
+                    }
+                }
+
+                if (songToPlayOnline != null) {
+                    val metadata = songToPlayOnline.toMediaMetadata()
+                    val queue = YouTubeQueue(WatchEndpoint(songToPlayOnline.id), metadata)
+
+                    withContext(Dispatchers.Main) {
+                        val service = ensureMusicService()
+                        if (service != null) {
+                            service.playQueue(queue, playWhenReady = true)
+                            service.player.play()
+                        } else {
+                            PlayerConnection.instance?.let {
+                                it.playQueue(queue)
+                                it.service.player.play()
+                            }
+                        }
+                        showToast("Playing: ${songToPlayOnline.title}", R.drawable.play)
+                    }
+
+                    val artistName = songToPlayOnline.artists.joinToString { it.name }
+                    if (artistName.isNotBlank()) {
+                        speak(context.getString(R.string.voice_playing_feedback, songToPlayOnline.title, artistName))
+                    } else {
+                        speak(context.getString(R.string.voice_playing_simple, songToPlayOnline.title))
+                    }
+                    return@launch
+                }
+
+                // Fallback to local cached songs if online returned no results
+                val localFallback = searchCachedLibrarySong(query)
+                if (localFallback != null) {
+                    playLocalCachedSong(localFallback)
+                } else {
+                    showToast("Song not found: \"$query\"", R.drawable.search_off)
+                    speak(context.getString(R.string.voice_song_not_found))
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error searching and playing song for query '%s'", query)
+                val localFallback = searchCachedLibrarySong(query)
+                if (localFallback != null) {
+                    playLocalCachedSong(localFallback)
+                } else {
+                    reportException(e)
+                    showToast("Error playing song", R.drawable.error)
+                    speak(context.getString(R.string.voice_song_not_found))
+                }
+            }
+        }
+    }
+
+    private fun ensureMusicService(): MusicService? {
+        val service = getMusicService() ?: PlayerConnection.instance?.service
+        if (service == null) {
+            try {
+                val intent = Intent(context, MusicService::class.java)
+                context.startService(intent)
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to start MusicService")
+            }
+        }
+        return service
+    }
+
+    fun release() {
+        try {
+            tts?.stop()
+            tts?.shutdown()
+            tts = null
+            isTtsReady = false
+        } catch (e: Exception) {
+            Timber.e(e, "Error releasing TextToSpeech")
+        }
+    }
+}

--- a/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceAssistantBootReceiver.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceAssistantBootReceiver.kt
@@ -1,0 +1,33 @@
+package com.darkxvenom.airbeats.voice
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.darkxvenom.airbeats.constants.EnableVoiceAssistantKey
+import com.darkxvenom.airbeats.constants.VoiceAssistantAutoStartOnBootKey
+import com.darkxvenom.airbeats.utils.dataStore
+import com.darkxvenom.airbeats.utils.get
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class VoiceAssistantBootReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val action = intent.action
+        if (action == Intent.ACTION_BOOT_COMPLETED || action == Intent.ACTION_MY_PACKAGE_REPLACED) {
+            Timber.i("VoiceAssistantBootReceiver triggered with action: %s", action)
+
+            CoroutineScope(Dispatchers.IO).launch {
+                val isEnabled = context.dataStore.get(EnableVoiceAssistantKey, false)
+                val autoStartOnBoot = context.dataStore.get(VoiceAssistantAutoStartOnBootKey, false)
+
+                if (isEnabled && autoStartOnBoot) {
+                    Timber.i("Auto-starting VoiceAssistantService after boot/update")
+                    VoiceAssistantService.start(context)
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceAssistantManager.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceAssistantManager.kt
@@ -1,0 +1,261 @@
+package com.darkxvenom.airbeats.voice
+
+import android.content.Context
+import android.content.Intent
+import android.media.AudioManager
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.speech.RecognitionListener
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import timber.log.Timber
+
+class VoiceAssistantManager(
+    private val context: Context,
+    private val onWakeWordHeard: ((String) -> Unit)? = null,
+    private val onCommandRecognized: (VoiceCommand, String) -> Unit
+) : RecognitionListener {
+
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager
+    private var speechRecognizer: SpeechRecognizer? = null
+    private var isRunning = false
+    private var requireWakeWord = true
+    private var isCurrentlyRecognizing = false
+    private var isSystemMuted = false
+
+    private val _isListening = MutableStateFlow(false)
+    val isListening: StateFlow<Boolean> = _isListening.asStateFlow()
+
+    private val _lastRecognizedText = MutableStateFlow<String?>(null)
+    val lastRecognizedText: StateFlow<String?> = _lastRecognizedText.asStateFlow()
+
+    private val _audioRms = MutableStateFlow(0f)
+    val audioRms: StateFlow<Float> = _audioRms.asStateFlow()
+
+    companion object {
+        private const val RESTART_DELAY_MS = 300L
+        private const val ERROR_RETRY_DELAY_MS = 800L
+    }
+
+    private val restartRunnable = Runnable {
+        if (isRunning) {
+            startRecognitionInternal()
+        }
+    }
+
+    fun start(requireWakeWord: Boolean = true) {
+        this.requireWakeWord = requireWakeWord
+        if (isRunning) return
+        isRunning = true
+
+        mainHandler.post {
+            ensureRecognizer()
+            startRecognitionInternal()
+        }
+    }
+
+    fun stop() {
+        isRunning = false
+        mainHandler.removeCallbacks(restartRunnable)
+        mainHandler.post {
+            restoreSystemSound()
+            try {
+                speechRecognizer?.stopListening()
+                speechRecognizer?.cancel()
+            } catch (e: Exception) {
+                Timber.e(e, "Error stopping SpeechRecognizer")
+            }
+            _isListening.value = false
+            isCurrentlyRecognizing = false
+        }
+    }
+
+    fun updateSettings(requireWakeWord: Boolean) {
+        this.requireWakeWord = requireWakeWord
+    }
+
+    private fun ensureRecognizer() {
+        if (speechRecognizer == null && SpeechRecognizer.isRecognitionAvailable(context)) {
+            try {
+                speechRecognizer = SpeechRecognizer.createSpeechRecognizer(context.applicationContext).apply {
+                    setRecognitionListener(this@VoiceAssistantManager)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Failed to create SpeechRecognizer")
+            }
+        }
+    }
+
+    private fun muteSystemSound() {
+        try {
+            audioManager?.adjustStreamVolume(AudioManager.STREAM_NOTIFICATION, AudioManager.ADJUST_MUTE, 0)
+            audioManager?.adjustStreamVolume(AudioManager.STREAM_SYSTEM, AudioManager.ADJUST_MUTE, 0)
+            isSystemMuted = true
+        } catch (_: Exception) {}
+    }
+
+    private fun restoreSystemSound() {
+        if (!isSystemMuted) return
+        try {
+            audioManager?.adjustStreamVolume(AudioManager.STREAM_NOTIFICATION, AudioManager.ADJUST_UNMUTE, 0)
+            audioManager?.adjustStreamVolume(AudioManager.STREAM_SYSTEM, AudioManager.ADJUST_UNMUTE, 0)
+            isSystemMuted = false
+        } catch (_: Exception) {}
+    }
+
+    private fun startRecognitionInternal() {
+        if (!isRunning) return
+        if (speechRecognizer == null) {
+            ensureRecognizer()
+        }
+
+        val recognizer = speechRecognizer ?: run {
+            Timber.w("SpeechRecognizer is not available on this device")
+            scheduleRestart(ERROR_RETRY_DELAY_MS)
+            return
+        }
+
+        try {
+            val intent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+                putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
+                putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 5)
+                putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, context.packageName)
+                putExtra("android.speech.extra.DICTATION_MODE", true)
+                putExtra("android.speech.extra.GET_AUDIO_FOCUS", false)
+                putExtra("android.speech.extra.AUDIO_FOCUS", false)
+                putExtra("android.speech.extra.SUPPRESS_SOUND", true)
+                putExtra("android.speech.extra.BEEP", false)
+                putExtra("android.speech.extra.SILENT_RECORDING", true)
+                putExtra("android.speech.extra.AUDIO_SOURCE", 6) // VOICE_RECOGNITION with echo cancellation
+            }
+
+            // Mute system sound temporarily to prevent Google SpeechRecognizer start ding/beep
+            muteSystemSound()
+
+            recognizer.cancel()
+            recognizer.startListening(intent)
+            _isListening.value = true
+            isCurrentlyRecognizing = true
+
+            // Unmute system sound shortly after start listening initializes
+            mainHandler.postDelayed({
+                restoreSystemSound()
+            }, 350)
+        } catch (e: Exception) {
+            Timber.e(e, "Error in startRecognitionInternal")
+            restoreSystemSound()
+            _isListening.value = false
+            isCurrentlyRecognizing = false
+            scheduleRestart(ERROR_RETRY_DELAY_MS)
+        }
+    }
+
+    private fun scheduleRestart(delayMs: Long = RESTART_DELAY_MS) {
+        if (!isRunning) return
+        mainHandler.removeCallbacks(restartRunnable)
+        mainHandler.postDelayed(restartRunnable, delayMs)
+    }
+
+    override fun onReadyForSpeech(params: Bundle?) {
+        _isListening.value = true
+        isCurrentlyRecognizing = true
+        restoreSystemSound()
+    }
+
+    override fun onBeginningOfSpeech() {
+        _isListening.value = true
+        restoreSystemSound()
+    }
+
+    override fun onRmsChanged(rmsdB: Float) {
+        _audioRms.value = rmsdB
+    }
+
+    override fun onBufferReceived(buffer: ByteArray?) {}
+
+    override fun onEndOfSpeech() {
+        _isListening.value = false
+        isCurrentlyRecognizing = false
+        restoreSystemSound()
+    }
+
+    override fun onError(error: Int) {
+        _isListening.value = false
+        isCurrentlyRecognizing = false
+        restoreSystemSound()
+        Timber.d("SpeechRecognizer onError: %d", error)
+
+        val delay = when (error) {
+            SpeechRecognizer.ERROR_SPEECH_TIMEOUT,
+            SpeechRecognizer.ERROR_NO_MATCH -> RESTART_DELAY_MS
+            SpeechRecognizer.ERROR_RECOGNIZER_BUSY,
+            SpeechRecognizer.ERROR_CLIENT -> {
+                try {
+                    speechRecognizer?.destroy()
+                } catch (_: Exception) {}
+                speechRecognizer = null
+                ERROR_RETRY_DELAY_MS
+            }
+            else -> ERROR_RETRY_DELAY_MS
+        }
+
+        scheduleRestart(delay)
+    }
+
+    override fun onResults(results: Bundle?) {
+        _isListening.value = false
+        isCurrentlyRecognizing = false
+        restoreSystemSound()
+
+        val matches = results?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+        if (!matches.isNullOrEmpty()) {
+            val topText = matches.first().trim()
+            _lastRecognizedText.value = topText
+            Timber.i("Spoken candidates recognized: %s", matches.joinToString(" | "))
+
+            var foundCommand = false
+            for (candidate in matches) {
+                val command = VoiceCommandParser.parse(candidate.trim(), requireWakeWord = requireWakeWord)
+                if (command !is VoiceCommand.Unknown) {
+                    onCommandRecognized(command, candidate.trim())
+                    foundCommand = true
+                    break
+                }
+            }
+        }
+
+        scheduleRestart(RESTART_DELAY_MS)
+    }
+
+    override fun onPartialResults(partialResults: Bundle?) {
+        val matches = partialResults?.getStringArrayList(SpeechRecognizer.RESULTS_RECOGNITION)
+        val partialText = matches?.firstOrNull()?.trim()
+        if (!partialText.isNullOrBlank()) {
+            _lastRecognizedText.value = partialText
+            if (VoiceCommandParser.containsWakeWord(partialText)) {
+                onWakeWordHeard?.invoke(partialText)
+            }
+        }
+    }
+
+    override fun onEvent(eventType: Int, params: Bundle?) {}
+
+    fun destroy() {
+        stop()
+        mainHandler.post {
+            restoreSystemSound()
+            try {
+                speechRecognizer?.destroy()
+            } catch (e: Exception) {
+                Timber.e(e, "Error destroying SpeechRecognizer")
+            }
+            speechRecognizer = null
+        }
+    }
+}

--- a/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceAssistantOverlayManager.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceAssistantOverlayManager.kt
@@ -1,0 +1,314 @@
+package com.darkxvenom.airbeats.voice
+
+import android.animation.ValueAnimator
+import android.content.Context
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.drawable.GradientDrawable
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import android.provider.Settings
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.view.WindowManager
+import android.view.animation.LinearInterpolator
+import android.widget.FrameLayout
+import android.widget.ImageView
+import android.widget.LinearLayout
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import com.darkxvenom.airbeats.R
+import timber.log.Timber
+
+class VoiceAssistantOverlayManager(private val context: Context) {
+
+    private val windowManager: WindowManager =
+        context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+    private val mainHandler = Handler(Looper.getMainLooper())
+
+    private var overlayView: View? = null
+    private var isOverlayShowing = false
+
+    private var actionIconView: ImageView? = null
+    private var statusTextView: TextView? = null
+    private var spokenTextView: TextView? = null
+    private var glowBar: View? = null
+    private var glowAnimator: ValueAnimator? = null
+
+    private val dismissRunnable = Runnable {
+        hide()
+    }
+
+    /**
+     * Checks if the app has permission to draw overlays over other apps.
+     */
+    fun canDrawOverlays(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Settings.canDrawOverlays(context)
+        } else {
+            true
+        }
+    }
+
+    /**
+     * Shows the floating bottom pill overlay with the initial listening state.
+     */
+    fun showListening() {
+        if (!canDrawOverlays()) return
+
+        mainHandler.post {
+            ensureOverlayCreated()
+            actionIconView?.setImageResource(R.drawable.mic)
+            actionIconView?.setColorFilter(Color.parseColor("#4285F4"))
+            statusTextView?.text = "AirBeats is listening..."
+            statusTextView?.setTextColor(Color.parseColor("#4285F4"))
+            spokenTextView?.visibility = View.GONE
+            spokenTextView?.text = ""
+
+            scheduleAutoDismiss(6000)
+        }
+    }
+
+    /**
+     * Updates the transcribed text in real-time as words are spoken.
+     */
+    fun updateSpokenText(text: String) {
+        if (!canDrawOverlays() || text.isBlank()) return
+
+        mainHandler.post {
+            ensureOverlayCreated()
+            actionIconView?.setImageResource(R.drawable.graphic_eq)
+            actionIconView?.setColorFilter(Color.parseColor("#4285F4"))
+            statusTextView?.text = "Listening:"
+            statusTextView?.setTextColor(Color.parseColor("#A0A0B0"))
+            spokenTextView?.visibility = View.VISIBLE
+            spokenTextView?.text = "\"$text\""
+
+            scheduleAutoDismiss(6000)
+        }
+    }
+
+    /**
+     * Displays the action result with a clean vector icon.
+     */
+    fun showActionResult(message: String, iconResId: Int = R.drawable.music_note) {
+        if (!canDrawOverlays()) return
+
+        mainHandler.post {
+            ensureOverlayCreated()
+            try {
+                actionIconView?.setImageResource(iconResId)
+                actionIconView?.setColorFilter(Color.parseColor("#34A853"))
+            } catch (_: Exception) {}
+
+            statusTextView?.text = "AirBeats"
+            statusTextView?.setTextColor(Color.parseColor("#34A853"))
+            spokenTextView?.visibility = View.VISIBLE
+            spokenTextView?.text = message
+
+            scheduleAutoDismiss(3500)
+        }
+    }
+
+    private fun scheduleAutoDismiss(delayMs: Long) {
+        mainHandler.removeCallbacks(dismissRunnable)
+        mainHandler.postDelayed(dismissRunnable, delayMs)
+    }
+
+    private fun ensureOverlayCreated() {
+        if (overlayView != null && isOverlayShowing) return
+
+        try {
+            val root = FrameLayout(context).apply {
+                layoutParams = FrameLayout.LayoutParams(
+                    FrameLayout.LayoutParams.MATCH_PARENT,
+                    FrameLayout.LayoutParams.WRAP_CONTENT
+                )
+            }
+
+            // Main pill container card
+            val card = LinearLayout(context).apply {
+                orientation = LinearLayout.VERTICAL
+                val bg = GradientDrawable().apply {
+                    setColor(Color.parseColor("#F5161622"))
+                    cornerRadii = floatArrayOf(
+                        dpToPx(28f), dpToPx(28f), // top-left
+                        dpToPx(28f), dpToPx(28f), // top-right
+                        0f, 0f, 0f, 0f
+                    )
+                    setStroke(dpToPx(1f).toInt(), Color.parseColor("#304285F4"))
+                }
+                background = bg
+                setPadding(dpToPx(18f).toInt(), dpToPx(10f).toInt(), dpToPx(18f).toInt(), dpToPx(22f).toInt())
+                elevation = dpToPx(12f)
+            }
+
+            // Top Shimmer Glow Bar
+            val glow = View(context).apply {
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    dpToPx(3.5f).toInt()
+                ).apply {
+                    bottomMargin = dpToPx(10f).toInt()
+                }
+                val glowGrad = GradientDrawable(
+                    GradientDrawable.Orientation.LEFT_RIGHT,
+                    intArrayOf(
+                        Color.parseColor("#4285F4"), // Blue
+                        Color.parseColor("#9B51E0"), // Purple
+                        Color.parseColor("#EA4335"), // Red
+                        Color.parseColor("#FBBC05"), // Amber
+                        Color.parseColor("#4285F4")  // Blue loop
+                    )
+                ).apply {
+                    cornerRadius = dpToPx(2f)
+                }
+                background = glowGrad
+            }
+            glowBar = glow
+            card.addView(glow)
+
+            // Content Header Row
+            val headerRow = LinearLayout(context).apply {
+                orientation = LinearLayout.HORIZONTAL
+                gravity = Gravity.CENTER_VERTICAL
+                layoutParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                )
+            }
+
+            // Action Vector Icon with Circular Badge
+            val iconFrame = FrameLayout(context).apply {
+                layoutParams = LinearLayout.LayoutParams(dpToPx(38f).toInt(), dpToPx(38f).toInt()).apply {
+                    marginEnd = dpToPx(12f).toInt()
+                }
+                background = GradientDrawable().apply {
+                    shape = GradientDrawable.OVAL
+                    setColor(Color.parseColor("#262638"))
+                }
+            }
+
+            val iconView = ImageView(context).apply {
+                layoutParams = FrameLayout.LayoutParams(dpToPx(22f).toInt(), dpToPx(22f).toInt()).apply {
+                    gravity = Gravity.CENTER
+                }
+                setImageResource(R.drawable.mic)
+                setColorFilter(Color.parseColor("#4285F4"))
+            }
+            actionIconView = iconView
+            iconFrame.addView(iconView)
+            headerRow.addView(iconFrame)
+
+            // Text column (Status + Spoken/Action Text)
+            val textCol = LinearLayout(context).apply {
+                orientation = LinearLayout.VERTICAL
+                layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            }
+
+            // Status label
+            val statusTv = TextView(context).apply {
+                text = "AirBeats is listening..."
+                setTextColor(Color.parseColor("#4285F4"))
+                textSize = 12f
+                paint.isFakeBoldText = true
+            }
+            statusTextView = statusTv
+            textCol.addView(statusTv)
+
+            // Spoken transcribed / Action text
+            val spokenTv = TextView(context).apply {
+                setTextColor(Color.WHITE)
+                textSize = 15f
+                paint.isFakeBoldText = true
+                visibility = View.GONE
+            }
+            spokenTextView = spokenTv
+            textCol.addView(spokenTv)
+
+            headerRow.addView(textCol)
+
+            // Close button (X)
+            val closeBtn = TextView(context).apply {
+                text = "✕"
+                setTextColor(Color.parseColor("#707080"))
+                textSize = 16f
+                setPadding(dpToPx(8f).toInt(), dpToPx(4f).toInt(), dpToPx(8f).toInt(), dpToPx(4f).toInt())
+                setOnClickListener { hide() }
+            }
+            headerRow.addView(closeBtn)
+
+            card.addView(headerRow)
+            root.addView(card)
+
+            val layoutParams = WindowManager.LayoutParams(
+                WindowManager.LayoutParams.MATCH_PARENT,
+                WindowManager.LayoutParams.WRAP_CONTENT,
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
+                    WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY
+                else
+                    WindowManager.LayoutParams.TYPE_PHONE,
+                WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_IN_SCREEN or
+                        WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
+                PixelFormat.TRANSLUCENT
+            ).apply {
+                gravity = Gravity.BOTTOM
+                windowAnimations = android.R.style.Animation_Toast
+            }
+
+            windowManager.addView(root, layoutParams)
+            overlayView = root
+            isOverlayShowing = true
+
+            startGlowAnimation()
+        } catch (e: Exception) {
+            Timber.e(e, "Error adding voice assistant overlay view")
+        }
+    }
+
+    private fun startGlowAnimation() {
+        glowAnimator?.cancel()
+        glowAnimator = ValueAnimator.ofFloat(0.6f, 1.0f).apply {
+            duration = 900
+            repeatMode = ValueAnimator.REVERSE
+            repeatCount = ValueAnimator.INFINITE
+            interpolator = LinearInterpolator()
+            addUpdateListener { anim ->
+                glowBar?.alpha = anim.animatedValue as Float
+            }
+            start()
+        }
+    }
+
+    /**
+     * Hides the floating bottom overlay.
+     */
+    fun hide() {
+        mainHandler.removeCallbacks(dismissRunnable)
+        mainHandler.post {
+            try {
+                glowAnimator?.cancel()
+                glowAnimator = null
+
+                if (overlayView != null && isOverlayShowing) {
+                    windowManager.removeView(overlayView)
+                    overlayView = null
+                    isOverlayShowing = false
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error removing voice assistant overlay view")
+            }
+        }
+    }
+
+    private fun dpToPx(dp: Float): Float {
+        return TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_DIP,
+            dp,
+            context.resources.displayMetrics
+        )
+    }
+}

--- a/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceAssistantService.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceAssistantService.kt
@@ -1,0 +1,280 @@
+package com.darkxvenom.airbeats.voice
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.content.pm.ServiceInfo
+import android.os.Build
+import android.os.IBinder
+import android.os.PowerManager
+import androidx.core.app.NotificationCompat
+import androidx.datastore.preferences.core.edit
+import com.darkxvenom.airbeats.MainActivity
+import com.darkxvenom.airbeats.R
+import com.darkxvenom.airbeats.constants.EnableVoiceAssistantKey
+import com.darkxvenom.airbeats.constants.VoiceAssistantDirectCommandsKey
+import com.darkxvenom.airbeats.playback.MusicService
+import com.darkxvenom.airbeats.utils.dataStore
+import com.darkxvenom.airbeats.utils.get
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+class VoiceAssistantService : Service() {
+
+    private val serviceScope = CoroutineScope(Dispatchers.Main + Job())
+    private var wakeLock: PowerManager.WakeLock? = null
+    private var musicService: MusicService? = null
+    private var isMusicServiceBound = false
+
+    private lateinit var voiceAssistantManager: VoiceAssistantManager
+    private lateinit var actionExecutor: VoiceAssistantActionExecutor
+
+    companion object {
+        const val NOTIFICATION_ID = 2001
+        const val CHANNEL_ID = "voice_assistant_channel"
+        const val ACTION_STOP_VOICE_ASSISTANT = "com.darkxvenom.airbeats.voice.STOP"
+
+        private val _isServiceRunning = MutableStateFlow(false)
+        val isServiceRunning: StateFlow<Boolean> = _isServiceRunning.asStateFlow()
+
+        @Volatile
+        var instance: VoiceAssistantService? = null
+            private set
+
+        fun start(context: Context) {
+            val intent = Intent(context, VoiceAssistantService::class.java)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                context.startForegroundService(intent)
+            } else {
+                context.startService(intent)
+            }
+        }
+
+        fun stop(context: Context) {
+            val intent = Intent(context, VoiceAssistantService::class.java)
+            context.stopService(intent)
+        }
+    }
+
+    private val musicServiceConnection = object : ServiceConnection {
+        override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+            if (binder is MusicService.MusicBinder) {
+                musicService = binder.service
+                Timber.d("VoiceAssistantService connected to MusicService")
+            }
+        }
+
+        override fun onServiceDisconnected(name: ComponentName?) {
+            musicService = null
+            Timber.d("VoiceAssistantService disconnected from MusicService")
+        }
+    }
+
+    private var overlayManager: VoiceAssistantOverlayManager? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        instance = this
+        _isServiceRunning.value = true
+
+        acquireWakeLock()
+        createNotificationChannel()
+        startAsForeground()
+        bindMusicService()
+
+        overlayManager = VoiceAssistantOverlayManager(this)
+
+        actionExecutor = VoiceAssistantActionExecutor(
+            context = this,
+            scope = serviceScope,
+            getMusicService = { musicService },
+            overlayManager = overlayManager
+        )
+
+        voiceAssistantManager = VoiceAssistantManager(
+            context = this,
+            onWakeWordHeard = { text ->
+                overlayManager?.showListening()
+                overlayManager?.updateSpokenText(text)
+            },
+            onCommandRecognized = { command, text ->
+                Timber.i("VoiceAssistantService received command: %s (from text: '%s')", command, text)
+                overlayManager?.updateSpokenText(text)
+                actionExecutor.execute(command)
+            }
+        )
+
+        serviceScope.launch {
+            val directCommands = dataStore.get(VoiceAssistantDirectCommandsKey, false)
+            val requireWakeWord = !directCommands
+            voiceAssistantManager.start(requireWakeWord = requireWakeWord)
+
+            // Observe direct command setting changes
+            dataStore.data.collectLatest {
+                val direct = it[VoiceAssistantDirectCommandsKey] ?: false
+                voiceAssistantManager.updateSettings(requireWakeWord = !direct)
+            }
+        }
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_STOP_VOICE_ASSISTANT) {
+            Timber.i("Stopping VoiceAssistantService via notification action")
+            serviceScope.launch {
+                dataStore.edit { preferences ->
+                    preferences[EnableVoiceAssistantKey] = false
+                }
+            }
+            stopSelf()
+            return START_NOT_STICKY
+        }
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    private fun startAsForeground() {
+        val notification = buildForegroundNotification()
+        try {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                startForeground(
+                    NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+                )
+            } else {
+                startForeground(NOTIFICATION_ID, notification)
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error starting VoiceAssistantService as foreground")
+        }
+    }
+
+    private fun buildForegroundNotification(): Notification {
+        val contentIntent = PendingIntent.getActivity(
+            this,
+            0,
+            Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_SINGLE_TOP or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val stopIntent = PendingIntent.getService(
+            this,
+            1,
+            Intent(this, VoiceAssistantService::class.java).apply {
+                action = ACTION_STOP_VOICE_ASSISTANT
+            },
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.airbeats_monochrome)
+            .setContentTitle(getString(R.string.voice_notification_title))
+            .setContentText(getString(R.string.voice_notification_text))
+            .setContentIntent(contentIntent)
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .addAction(
+                R.drawable.airbeats_monochrome,
+                getString(R.string.voice_notification_stop),
+                stopIntent
+            )
+            .build()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                getString(R.string.voice_notification_channel),
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = getString(R.string.voice_assistant_desc)
+                setShowBadge(false)
+            }
+            val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            notificationManager.createNotificationChannel(channel)
+        }
+    }
+
+    private fun acquireWakeLock() {
+        try {
+            val powerManager = getSystemService(Context.POWER_SERVICE) as PowerManager
+            wakeLock = powerManager.newWakeLock(
+                PowerManager.PARTIAL_WAKE_LOCK,
+                "AirBeats:VoiceAssistantWakeLock"
+            ).apply {
+                setReferenceCounted(false)
+                acquire(12 * 60 * 60 * 1000L) // 12 hours max safety limit
+            }
+        } catch (e: Exception) {
+            Timber.e(e, "Error acquiring wake lock")
+        }
+    }
+
+    private fun releaseWakeLock() {
+        try {
+            if (wakeLock?.isHeld == true) {
+                wakeLock?.release()
+            }
+            wakeLock = null
+        } catch (e: Exception) {
+            Timber.e(e, "Error releasing wake lock")
+        }
+    }
+
+    private fun bindMusicService() {
+        try {
+            val intent = Intent(this, MusicService::class.java)
+            startService(intent)
+            isMusicServiceBound = bindService(intent, musicServiceConnection, Context.BIND_AUTO_CREATE)
+        } catch (e: Exception) {
+            Timber.e(e, "Error binding to MusicService")
+        }
+    }
+
+    private fun unbindMusicService() {
+        if (isMusicServiceBound) {
+            try {
+                unbindService(musicServiceConnection)
+                isMusicServiceBound = false
+            } catch (e: Exception) {
+                Timber.e(e, "Error unbinding from MusicService")
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        _isServiceRunning.value = false
+        instance = null
+
+        overlayManager?.hide()
+        overlayManager = null
+
+        voiceAssistantManager.destroy()
+        actionExecutor.release()
+        releaseWakeLock()
+        unbindMusicService()
+        serviceScope.cancel()
+
+        super.onDestroy()
+        Timber.d("VoiceAssistantService destroyed")
+    }
+}

--- a/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceCommand.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceCommand.kt
@@ -1,0 +1,20 @@
+package com.darkxvenom.airbeats.voice
+
+sealed interface VoiceCommand {
+    data class PlaySong(val query: String) : VoiceCommand
+    data object PlayGenericMusic : VoiceCommand
+    data object PlayCachedSongs : VoiceCommand
+    data object PlayLikedSongs : VoiceCommand
+    data object Pause : VoiceCommand
+    data object Resume : VoiceCommand
+    data object NextTrack : VoiceCommand
+    data object PreviousTrack : VoiceCommand
+    data object ToggleLike : VoiceCommand
+    data object StartRadio : VoiceCommand
+    data object VolumeUp : VoiceCommand
+    data object VolumeDown : VoiceCommand
+    data class SetVolume(val levelPercent: Int) : VoiceCommand
+    data object Mute : VoiceCommand
+    data object Unmute : VoiceCommand
+    data class Unknown(val rawText: String) : VoiceCommand
+}

--- a/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceCommandParser.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/voice/VoiceCommandParser.kt
@@ -1,0 +1,208 @@
+package com.darkxvenom.airbeats.voice
+
+import java.util.Locale
+
+object VoiceCommandParser {
+
+    private val WAKE_WORD_PATTERNS = listOf(
+        "(?:hi|hey|ok|hello|hai|ay|yo)?\\s*air\\s*beats?",
+        "(?:hi|hey|ok|hello|hai|ay|yo)?\\s*aerobeats?",
+        "(?:hi|hey|ok|hello|hai|ay|yo)?\\s*air\\s*beat",
+        "(?:hi|hey|ok|hello|hai|ay|yo)?\\s*air\\s*bits?",
+        "(?:hi|hey|ok|hello|hai|ay|yo)?\\s*air\\s*base"
+    )
+
+    private val WAKE_WORD_REGEX = Regex(
+        "^\\s*(?:${WAKE_WORD_PATTERNS.joinToString("|")})[,\\s]*",
+        RegexOption.IGNORE_CASE
+    )
+
+    private val VOLUME_PERCENT_REGEX = Regex(
+        "(?:set\\s+|change\\s+|put\\s+|make\\s+|turn\\s+)?volume(?:\\s+to|\\s+at)?\\s+(\\d{1,3})(?:\\s*%)?|(\\d{1,3})(?:\\s*%|\\s+percent)(?:\\s+volume)?",
+        RegexOption.IGNORE_CASE
+    )
+
+    private val PLAY_CACHED_REGEX = Regex(
+        "^(?:play\\s+|listen\\s+to\\s+|stream\\s+)?(?:my\\s+)?(?:cached|cache|downloaded|download|downloads|offline|saved|local|library|stored)\\s*(?:songs?|tracks?|music)?$" +
+                "|^(?:play\\s+|listen\\s+to\\s+)?(?:songs?|music|tracks?)\\s+from\\s+(?:my\\s+)?(?:library|cache|downloads?|storage)$",
+        RegexOption.IGNORE_CASE
+    )
+
+    private val PLAY_LIKED_REGEX = Regex(
+        "^(?:play\\s+|listen\\s+to\\s+|stream\\s+)?(?:my\\s+)?(?:liked|favorites?|favourites?|loved)\\s*(?:songs?|tracks?|music)?$" +
+                "|^(?:play\\s+|listen\\s+to\\s+)?(?:songs?|music|tracks?)\\s+from\\s+(?:my\\s+)?(?:favorites?|favourites?|liked)$",
+        RegexOption.IGNORE_CASE
+    )
+
+    /**
+     * Checks whether the given spoken text contains an AirBeats wake word.
+     */
+    fun containsWakeWord(text: String): Boolean {
+        val trimmed = text.trim()
+        return WAKE_WORD_REGEX.containsMatchIn(trimmed) ||
+                trimmed.lowercase(Locale.ROOT).contains("airbeat") ||
+                trimmed.lowercase(Locale.ROOT).contains("air beats") ||
+                trimmed.lowercase(Locale.ROOT).contains("aerobeat")
+    }
+
+    /**
+     * Parses spoken text into a [VoiceCommand].
+     */
+    fun parse(rawText: String, requireWakeWord: Boolean = true): VoiceCommand {
+        val trimmed = rawText.trim().lowercase(Locale.ROOT)
+            .replace(Regex("[.,!?;:]"), "")
+            .trim()
+
+        if (trimmed.isBlank()) {
+            return VoiceCommand.Unknown(rawText)
+        }
+
+        val hasWakeWord = containsWakeWord(trimmed)
+        if (requireWakeWord && !hasWakeWord) {
+            return VoiceCommand.Unknown(rawText)
+        }
+
+        // Strip wake word prefix if present
+        val commandBody = WAKE_WORD_REGEX.replace(trimmed, "").trim()
+
+        if (commandBody.isEmpty()) {
+            return VoiceCommand.Unknown(rawText)
+        }
+
+        return parseCommandBody(commandBody, rawText, hasWakeWord)
+    }
+
+    private fun parseCommandBody(body: String, rawOriginal: String, hasWakeWord: Boolean): VoiceCommand {
+        val normalized = body.trim()
+
+        // 1. Play Cached / Downloaded / Library Songs
+        if (PLAY_CACHED_REGEX.matches(normalized)) {
+            return VoiceCommand.PlayCachedSongs
+        }
+
+        // 2. Play Liked / Favorite Songs
+        if (PLAY_LIKED_REGEX.matches(normalized)) {
+            return VoiceCommand.PlayLikedSongs
+        }
+
+        // 3. Generic Play Songs / Play Music
+        if (normalized == "play songs" || normalized == "play song" || normalized == "play some songs" ||
+            normalized == "play music" || normalized == "play some music" || normalized == "start music" ||
+            normalized == "play something" || normalized == "play anything" || normalized == "shuffle music" ||
+            normalized == "shuffle songs"
+        ) {
+            return VoiceCommand.PlayGenericMusic
+        }
+
+        // 4. Play / Search Song with explicit prefix
+        val playPrefixMatch = Regex(
+            "^(?:play|listen\\s+to|put\\s+on|stream|find)(?:\\s+the\\s+song|\\s+the\\s+track|\\s+song|\\s+track)?(?:\\s+called)?(?:\\s+)(.+)$",
+            RegexOption.IGNORE_CASE
+        ).find(normalized)
+
+        if (playPrefixMatch != null) {
+            val query = playPrefixMatch.groupValues[1]
+                .replace(Regex("^(?:the\\s+)?music\\s+", RegexOption.IGNORE_CASE), "")
+                .trim()
+            if (query.isNotBlank() && query != "music" && query != "song" && query != "songs" && query != "something" && query != "anything") {
+                return VoiceCommand.PlaySong(query)
+            }
+        }
+
+        // 5. Simple Resume / Play without query
+        if (normalized == "play" || normalized == "resume" || normalized == "continue" ||
+            normalized == "unpause"
+        ) {
+            return VoiceCommand.Resume
+        }
+
+        // 5. Pause / Stop
+        if (normalized == "pause" || normalized == "stop" || normalized == "pause music" ||
+            normalized == "stop music" || normalized == "halt" || normalized == "freeze" ||
+            normalized == "shut up" || normalized == "hold on"
+        ) {
+            return VoiceCommand.Pause
+        }
+
+        // 6. Next Track / Skip
+        if (normalized == "next" || normalized == "skip" || normalized == "next song" ||
+            normalized == "next track" || normalized == "skip song" || normalized == "skip track" ||
+            normalized == "play next" || normalized == "skip this"
+        ) {
+            return VoiceCommand.NextTrack
+        }
+
+        // 7. Previous Track / Back
+        if (normalized == "previous" || normalized == "previous song" || normalized == "previous track" ||
+            normalized == "go back" || normalized == "back" || normalized == "last song" ||
+            normalized == "play previous" || normalized == "replay song"
+        ) {
+            return VoiceCommand.PreviousTrack
+        }
+
+        // 8. Like / Favorite
+        if (normalized == "like" || normalized == "like this song" || normalized == "like the song" ||
+            normalized == "favorite" || normalized == "add to favorites" || normalized == "love this song" ||
+            normalized == "thumbs up" || normalized == "thumb up"
+        ) {
+            return VoiceCommand.ToggleLike
+        }
+
+        // 9. Radio
+        if (normalized == "start radio" || normalized == "play radio" || normalized == "radio" ||
+            normalized == "start station" || normalized == "similar songs" || normalized == "more like this"
+        ) {
+            return VoiceCommand.StartRadio
+        }
+
+        // 10. Volume Controls
+        val volumeMatch = VOLUME_PERCENT_REGEX.find(normalized)
+        if (volumeMatch != null) {
+            val levelStr = volumeMatch.groupValues[1].ifBlank { volumeMatch.groupValues[2] }
+            val level = levelStr.toIntOrNull()
+            if (level != null) {
+                return VoiceCommand.SetVolume(level.coerceIn(0, 100))
+            }
+        }
+
+        if (normalized == "volume up" || normalized == "increase volume" || normalized == "louder" ||
+            normalized == "turn it up" || normalized == "turn up" || normalized == "raise volume"
+        ) {
+            return VoiceCommand.VolumeUp
+        }
+
+        if (normalized == "volume down" || normalized == "decrease volume" || normalized == "softer" ||
+            normalized == "turn it down" || normalized == "turn down" || normalized == "lower volume"
+        ) {
+            return VoiceCommand.VolumeDown
+        }
+
+        if (normalized == "mute" || normalized == "silence" || normalized == "be quiet") {
+            return VoiceCommand.Mute
+        }
+
+        if (normalized == "unmute") {
+            return VoiceCommand.Unmute
+        }
+
+        // 11. If wake word was spoken followed directly by a song title (e.g. "Hi AirBeats Starboy")
+        if (hasWakeWord && normalized.length >= 2 && !isControlKeyword(normalized)) {
+            val cleanSong = normalized
+                .replace(Regex("^(?:song|track|music)\\s+", RegexOption.IGNORE_CASE), "")
+                .trim()
+            if (cleanSong.isNotBlank()) {
+                return VoiceCommand.PlaySong(cleanSong)
+            }
+        }
+
+        return VoiceCommand.Unknown(rawOriginal)
+    }
+
+    private fun isControlKeyword(text: String): Boolean {
+        val controls = listOf(
+            "play", "pause", "stop", "resume", "next", "skip", "previous", "back",
+            "like", "favorite", "radio", "volume", "mute", "unmute"
+        )
+        return controls.contains(text.lowercase(Locale.ROOT))
+    }
+}

--- a/app/src/test/java/com/darkxvenom/airbeats/voice/VoiceCommandParserTest.kt
+++ b/app/src/test/java/com/darkxvenom/airbeats/voice/VoiceCommandParserTest.kt
@@ -1,0 +1,133 @@
+package com.darkxvenom.airbeats.voice
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class VoiceCommandParserTest {
+
+    @Test
+    fun testWakeWordDetection() {
+        assertTrue(VoiceCommandParser.containsWakeWord("hi airbeats play song"))
+        assertTrue(VoiceCommandParser.containsWakeWord("hey airbeats pause"))
+        assertTrue(VoiceCommandParser.containsWakeWord("ok airbeats next"))
+        assertTrue(VoiceCommandParser.containsWakeWord("airbeats volume up"))
+        assertTrue(VoiceCommandParser.containsWakeWord("aerobeats resume"))
+        assertTrue(VoiceCommandParser.containsWakeWord("air beats like"))
+        assertTrue(VoiceCommandParser.containsWakeWord("air bit play believer"))
+        assertTrue(VoiceCommandParser.containsWakeWord("ear beats play starboy"))
+        assertTrue(VoiceCommandParser.containsWakeWord("hair beats skip"))
+    }
+
+    @Test
+    fun testPlayCachedAndLibrarySongs() {
+        assertEquals(VoiceCommand.PlayCachedSongs, VoiceCommandParser.parse("Hi AirBeats play cached songs"))
+        assertEquals(VoiceCommand.PlayCachedSongs, VoiceCommandParser.parse("Hey AirBeats, play cache"))
+        assertEquals(VoiceCommand.PlayCachedSongs, VoiceCommandParser.parse("AirBeats play library songs"))
+        assertEquals(VoiceCommand.PlayCachedSongs, VoiceCommandParser.parse("Hi AirBeats play songs from library"))
+        assertEquals(VoiceCommand.PlayCachedSongs, VoiceCommandParser.parse("AirBeats play my library"))
+        assertEquals(VoiceCommand.PlayCachedSongs, VoiceCommandParser.parse("AirBeats play downloaded songs"))
+        assertEquals(VoiceCommand.PlayCachedSongs, VoiceCommandParser.parse("AirBeats play offline songs"))
+        assertEquals(VoiceCommand.PlayCachedSongs, VoiceCommandParser.parse("AirBeats play saved songs"))
+        assertEquals(VoiceCommand.PlayCachedSongs, VoiceCommandParser.parse("play cached songs", requireWakeWord = false))
+    }
+
+    @Test
+    fun testPlayLikedSongs() {
+        assertEquals(VoiceCommand.PlayLikedSongs, VoiceCommandParser.parse("Hi AirBeats play liked songs"))
+        assertEquals(VoiceCommand.PlayLikedSongs, VoiceCommandParser.parse("AirBeats play favorites"))
+        assertEquals(VoiceCommand.PlayLikedSongs, VoiceCommandParser.parse("Hi AirBeats play my favorites"))
+    }
+
+    @Test
+    fun testPlaySongParsingWithWakeWord() {
+        val cmd1 = VoiceCommandParser.parse("Hi AirBeats, play Starboy")
+        assertEquals(VoiceCommand.PlaySong("starboy"), cmd1)
+
+        val cmd2 = VoiceCommandParser.parse("Hey AirBeats play Bohemian Rhapsody by Queen")
+        assertEquals(VoiceCommand.PlaySong("bohemian rhapsody by queen"), cmd2)
+
+        val cmd3 = VoiceCommandParser.parse("airbeats play song Shape of You")
+        assertEquals(VoiceCommand.PlaySong("shape of you"), cmd3)
+
+        val cmd4 = VoiceCommandParser.parse("Air beats, listen to Blinding Lights")
+        assertEquals(VoiceCommand.PlaySong("blinding lights"), cmd4)
+
+        val cmd5 = VoiceCommandParser.parse("Ok Airbeats put on Despacito")
+        assertEquals(VoiceCommand.PlaySong("despacito"), cmd5)
+
+        val cmd6 = VoiceCommandParser.parse("Air beats please play Believer")
+        assertEquals(VoiceCommand.PlaySong("believer"), cmd6)
+
+        val cmd7 = VoiceCommandParser.parse("Hi AirBeats Shape of You")
+        assertEquals(VoiceCommand.PlaySong("shape of you"), cmd7)
+    }
+
+    @Test
+    fun testDirectCommandsMode() {
+        val cmd1 = VoiceCommandParser.parse("play Starboy", requireWakeWord = false)
+        assertEquals(VoiceCommand.PlaySong("starboy"), cmd1)
+
+        val cmd2 = VoiceCommandParser.parse("pause", requireWakeWord = false)
+        assertEquals(VoiceCommand.Pause, cmd2)
+
+        val cmd3 = VoiceCommandParser.parse("next song", requireWakeWord = false)
+        assertEquals(VoiceCommand.NextTrack, cmd3)
+
+        val cmd4 = VoiceCommandParser.parse("previous song", requireWakeWord = false)
+        assertEquals(VoiceCommand.PreviousTrack, cmd4)
+
+        val cmd5 = VoiceCommandParser.parse("resume", requireWakeWord = false)
+        assertEquals(VoiceCommand.Resume, cmd5)
+    }
+
+    @Test
+    fun testPlaybackControls() {
+        assertEquals(VoiceCommand.Pause, VoiceCommandParser.parse("Hi AirBeats pause"))
+        assertEquals(VoiceCommand.Pause, VoiceCommandParser.parse("Hey AirBeats, stop music"))
+        assertEquals(VoiceCommand.Resume, VoiceCommandParser.parse("AirBeats resume"))
+        assertEquals(VoiceCommand.Resume, VoiceCommandParser.parse("AirBeats continue"))
+        assertEquals(VoiceCommand.NextTrack, VoiceCommandParser.parse("Hi AirBeats next"))
+        assertEquals(VoiceCommand.NextTrack, VoiceCommandParser.parse("Hi AirBeats skip"))
+        assertEquals(VoiceCommand.NextTrack, VoiceCommandParser.parse("Hi AirBeats next song"))
+        assertEquals(VoiceCommand.PreviousTrack, VoiceCommandParser.parse("Hi AirBeats previous"))
+        assertEquals(VoiceCommand.PreviousTrack, VoiceCommandParser.parse("Hi AirBeats back"))
+        assertEquals(VoiceCommand.PreviousTrack, VoiceCommandParser.parse("Hi AirBeats previous song"))
+    }
+
+    @Test
+    fun testLikeAndRadio() {
+        assertEquals(VoiceCommand.ToggleLike, VoiceCommandParser.parse("Hi AirBeats like this song"))
+        assertEquals(VoiceCommand.ToggleLike, VoiceCommandParser.parse("AirBeats favorite"))
+        assertEquals(VoiceCommand.StartRadio, VoiceCommandParser.parse("Hi AirBeats start radio"))
+        assertEquals(VoiceCommand.StartRadio, VoiceCommandParser.parse("AirBeats radio"))
+    }
+
+    @Test
+    fun testPlayGenericMusic() {
+        assertEquals(VoiceCommand.PlayGenericMusic, VoiceCommandParser.parse("Hi AirBeats play songs"))
+        assertEquals(VoiceCommand.PlayGenericMusic, VoiceCommandParser.parse("AirBeats play song"))
+        assertEquals(VoiceCommand.PlayGenericMusic, VoiceCommandParser.parse("Hi AirBeats play some music"))
+        assertEquals(VoiceCommand.PlayGenericMusic, VoiceCommandParser.parse("AirBeats play music"))
+    }
+
+    @Test
+    fun testVolumeControls() {
+        assertEquals(VoiceCommand.VolumeUp, VoiceCommandParser.parse("Hi AirBeats volume up"))
+        assertEquals(VoiceCommand.VolumeUp, VoiceCommandParser.parse("AirBeats increase volume"))
+        assertEquals(VoiceCommand.VolumeDown, VoiceCommandParser.parse("Hi AirBeats volume down"))
+        assertEquals(VoiceCommand.VolumeDown, VoiceCommandParser.parse("AirBeats lower volume"))
+        assertEquals(VoiceCommand.SetVolume(80), VoiceCommandParser.parse("Hi AirBeats set volume to 80%"))
+        assertEquals(VoiceCommand.SetVolume(50), VoiceCommandParser.parse("AirBeats volume 50"))
+        assertEquals(VoiceCommand.SetVolume(20), VoiceCommandParser.parse("Hi AirBeats volume 20 %"))
+        assertEquals(VoiceCommand.SetVolume(20), VoiceCommandParser.parse("AirBeats 20% volume"))
+        assertEquals(VoiceCommand.Mute, VoiceCommandParser.parse("Hi AirBeats mute"))
+        assertEquals(VoiceCommand.Unmute, VoiceCommandParser.parse("Hi AirBeats unmute"))
+    }
+
+    @Test
+    fun testRandomConversationRejection() {
+        val cmd = VoiceCommandParser.parse("how is the weather outside", requireWakeWord = true)
+        assertTrue(cmd is VoiceCommand.Unknown)
+    }
+}


### PR DESCRIPTION
## Summary of Changes

This Pull Request introduces significant enhancements to the AirBeats Voice Assistant, UI feedback, and offline playback:

### 🎙️ 1. Voice Engine & Silent Continuous Recognition
- Completely suppressed Android system SpeechRecognizer start/restart beeps via targeted audio stream attenuation.
- Smart continuous background listening with wake word detection and direct command execution.

### ⏪ 2. Navigation & Player Control Fixes
- Forced previous track skipping using `seekToPreviousMediaItem()` so saying *"previous song"* immediately jumps to the previous track instead of replaying from `0:00`.
- Persistent volume control (e.g. *"volume 20%"*) that locks into system & service streams without bouncing back.

### 🔀 3. Smart Taste-Based Online / Offline Playback
- Saying *"play songs"* or *"play music"* spins up a personalized YouTube Music radio station tailored to the user's top-played artists and tracks.
- When offline, automatically falls back to shuffling and playing all cached & stored library songs.
- Multi-tiered fuzzy search for local cached songs when offline.

### 🎨 4. Floating HUD & UI Improvements
- Floating HUD pill uses dedicated Android vector icon badges (`R.drawable.skip_previous`, `R.drawable.skip_next`, `R.drawable.play`, `R.drawable.pause`, `R.drawable.volume_up`, `R.drawable.favorite`, etc.).
- Complete redesign of the first-time Profile Setup screen with high-contrast text and theme-adaptive card.
