### PR TITLE
feat: offline skip for uncached songs, cache backup & restore with full offline playback, and crash fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ sudo snap install airbeats
 - <img src="https://avatars.githubusercontent.com/u/241423835" width="60" style="border-radius: 50%; margin-top: 10px;"/>
 **Venom** - Creative Design Visionary
 - 🔗 [GitHub](https://github.com/drkvenom786)
-- 🌐 [Website](http://venomx.pro)
+- 🌐 [Website](https://drkvenom786.github.io/webpage/)
 - 🎨 [Portfolio](https://drkvenom786.github.io/webpage/)
 
 ---

--- a/app/src/main/java/com/darkxvenom/airbeats/constants/PreferenceKeys.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/constants/PreferenceKeys.kt
@@ -107,6 +107,7 @@ val AudioNormalizationKey = booleanPreferencesKey("audioNormalization")
 val AutoLoadMoreKey = booleanPreferencesKey("autoLoadMore")
 val SimilarContent = booleanPreferencesKey("similarContent")
 val AutoSkipNextOnErrorKey = booleanPreferencesKey("autoSkipNextOnError")
+val SkipUncachedPartKey = booleanPreferencesKey("skipUncachedPart")
 val StopMusicOnTaskClearKey = booleanPreferencesKey("stopMusicOnTaskClear")
 val CrossfadeKey = intPreferencesKey("crossfade")
 

--- a/app/src/main/java/com/darkxvenom/airbeats/db/entities/Song.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/db/entities/Song.kt
@@ -41,4 +41,6 @@ constructor(
         get() = song.title
     override val thumbnailUrl: String?
         get() = song.thumbnailUrl
+    val duration: Int
+        get() = song.duration
 }

--- a/app/src/main/java/com/darkxvenom/airbeats/di/AppModule.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/di/AppModule.kt
@@ -51,6 +51,7 @@ object AppModule {
         @ApplicationContext context: Context,
         databaseProvider: DatabaseProvider,
     ): SimpleCache {
+        ensureCacheUidAligned(context, "exoplayer")
         val constructor = {
             SimpleCache(
                 context.filesDir.resolve("exoplayer"),
@@ -72,10 +73,100 @@ object AppModule {
         @ApplicationContext context: Context,
         databaseProvider: DatabaseProvider,
     ): SimpleCache {
+        ensureCacheUidAligned(context, "download")
         val constructor = {
             SimpleCache(context.filesDir.resolve("download"), NoOpCacheEvictor(), databaseProvider)
         }
         constructor().release()
         return constructor()
+    }
+
+    fun ensureCacheUidAligned(context: Context, dirName: String) {
+        try {
+            val dir = context.filesDir.resolve(dirName)
+            if (!dir.exists()) return
+            val dbFile = context.getDatabasePath("exoplayer_internal.db")
+            if (!dbFile.exists()) return
+
+            android.database.sqlite.SQLiteDatabase.openDatabase(
+                dbFile.path,
+                null,
+                android.database.sqlite.SQLiteDatabase.OPEN_READWRITE
+            ).use { db ->
+                try {
+                    db.rawQuery("PRAGMA wal_checkpoint(FULL)", null).use { it.moveToFirst() }
+                } catch (_: Exception) {}
+
+                val tables = mutableListOf<String>()
+                db.rawQuery(
+                    "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'ExoPlayerCacheIndex%'",
+                    null
+                ).use { cursor ->
+                    while (cursor.moveToNext()) {
+                        tables.add(cursor.getString(0))
+                    }
+                }
+
+                if (tables.isEmpty()) return
+
+                // Scan files in dir to find any cached chunk IDs (e.g. "0.0.1234.v3.exo" -> id = 0)
+                val chunkIds = mutableSetOf<Int>()
+                dir.listFiles()?.forEach { file ->
+                    val name = file.name
+                    if (name.endsWith(".exo")) {
+                        val idPart = name.substringBefore('.')
+                        idPart.toIntOrNull()?.let { chunkIds.add(it) }
+                    }
+                }
+
+                var bestHexUid: String? = null
+                var maxMatchingRows = -1
+
+                for (table in tables) {
+                    val hex = table.removePrefix("ExoPlayerCacheIndex")
+                    var matchingScore = 0
+
+                    if (chunkIds.isNotEmpty()) {
+                        for (chunkId in chunkIds.take(10)) {
+                            val count = try {
+                                db.rawQuery("SELECT count(*) FROM $table WHERE id = $chunkId", null).use { c ->
+                                    if (c.moveToFirst()) c.getInt(0) else 0
+                                }
+                            } catch (_: Exception) { 0 }
+                            if (count > 0) matchingScore++
+                        }
+                    }
+
+                    val totalRows = try {
+                        db.rawQuery("SELECT count(*) FROM $table", null).use { c ->
+                            if (c.moveToFirst()) c.getInt(0) else 0
+                        }
+                    } catch (_: Exception) { 0 }
+
+                    val finalScore = if (matchingScore > 0) matchingScore * 1000 + totalRows else totalRows
+
+                    if (finalScore > maxMatchingRows) {
+                        maxMatchingRows = finalScore
+                        bestHexUid = hex
+                    }
+                }
+
+                if (!bestHexUid.isNullOrEmpty()) {
+                    val uidFiles = dir.listFiles { _, name -> name.endsWith(".uid") } ?: emptyArray()
+                    val targetName = "$bestHexUid.uid"
+                    var targetExists = false
+                    for (f in uidFiles) {
+                        if (f.name.equals(targetName, ignoreCase = true)) {
+                            targetExists = true
+                        } else {
+                            f.delete()
+                        }
+                    }
+                    if (!targetExists) {
+                        dir.resolve(targetName).createNewFile()
+                    }
+                }
+            }
+        } catch (_: Exception) {}
     }
 }

--- a/app/src/main/java/com/darkxvenom/airbeats/di/AppModule.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/di/AppModule.kt
@@ -149,11 +149,11 @@ object AppModule {
                         }
                     }
 
-                    val totalRows = try {
+                    val totalRows: Int = try {
                         db.rawQuery("SELECT count(*) FROM $table", null).use { c ->
                             if (c.moveToFirst()) c.getInt(0) else 0
                         }
-                    } catch (_: Exception) {}
+                    } catch (_: Exception) { 0 }
 
                     val finalScore = if (matchingScore > 0) matchingScore * 1000 + totalRows else totalRows
 

--- a/app/src/main/java/com/darkxvenom/airbeats/di/AppModule.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/di/AppModule.kt
@@ -85,39 +85,51 @@ object AppModule {
         try {
             val dir = context.filesDir.resolve(dirName)
             if (!dir.exists()) return
-            val dbFile = context.getDatabasePath("exoplayer_internal.db")
-            if (!dbFile.exists()) return
 
-            android.database.sqlite.SQLiteDatabase.openDatabase(
+            // 1. Collect all chunk IDs from .exo files recursively
+            val chunkIds = mutableSetOf<Int>()
+            try {
+                dir.walkTopDown().forEach { file ->
+                    if (file.isFile && file.name.endsWith(".exo")) {
+                        val idPart = file.name.substringBefore('.')
+                        idPart.toIntOrNull()?.let { chunkIds.add(it) }
+                    }
+                }
+            } catch (_: Exception) {}
+
+            val dbFile = context.getDatabasePath("exoplayer_internal.db")
+            dbFile.parentFile?.mkdirs()
+
+            android.database.sqlite.SQLiteDatabase.openOrCreateDatabase(
                 dbFile.path,
-                null,
-                android.database.sqlite.SQLiteDatabase.OPEN_READWRITE
+                null
             ).use { db ->
                 try {
                     db.rawQuery("PRAGMA wal_checkpoint(FULL)", null).use { it.moveToFirst() }
                 } catch (_: Exception) {}
 
+                // Ensure ExoPlayerVersions table exists
+                try {
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS ExoPlayerVersions (" +
+                        "feature INTEGER NOT NULL, " +
+                        "instance_uid TEXT NOT NULL, " +
+                        "version INTEGER NOT NULL, " +
+                        "PRIMARY KEY (feature, instance_uid))"
+                    )
+                } catch (_: Exception) {}
+
                 val tables = mutableListOf<String>()
-                db.rawQuery(
-                    "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'ExoPlayerCacheIndex%'",
-                    null
-                ).use { cursor ->
-                    while (cursor.moveToNext()) {
-                        tables.add(cursor.getString(0))
+                try {
+                    db.rawQuery(
+                        "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'ExoPlayerCacheIndex%'",
+                        null
+                    ).use { cursor ->
+                        while (cursor.moveToNext()) {
+                            tables.add(cursor.getString(0))
+                        }
                     }
-                }
-
-                if (tables.isEmpty()) return
-
-                // Scan files in dir to find any cached chunk IDs (e.g. "0.0.1234.v3.exo" -> id = 0)
-                val chunkIds = mutableSetOf<Int>()
-                dir.listFiles()?.forEach { file ->
-                    val name = file.name
-                    if (name.endsWith(".exo")) {
-                        val idPart = name.substringBefore('.')
-                        idPart.toIntOrNull()?.let { chunkIds.add(it) }
-                    }
-                }
+                } catch (_: Exception) {}
 
                 var bestHexUid: String? = null
                 var maxMatchingRows = -1
@@ -127,7 +139,7 @@ object AppModule {
                     var matchingScore = 0
 
                     if (chunkIds.isNotEmpty()) {
-                        for (chunkId in chunkIds.take(10)) {
+                        for (chunkId in chunkIds) {
                             val count = try {
                                 db.rawQuery("SELECT count(*) FROM $table WHERE id = $chunkId", null).use { c ->
                                     if (c.moveToFirst()) c.getInt(0) else 0
@@ -141,7 +153,7 @@ object AppModule {
                         db.rawQuery("SELECT count(*) FROM $table", null).use { c ->
                             if (c.moveToFirst()) c.getInt(0) else 0
                         }
-                    } catch (_: Exception) { 0 }
+                    } catch (_: Exception) {}
 
                     val finalScore = if (matchingScore > 0) matchingScore * 1000 + totalRows else totalRows
 
@@ -151,21 +163,110 @@ object AppModule {
                     }
                 }
 
-                if (!bestHexUid.isNullOrEmpty()) {
-                    val uidFiles = dir.listFiles { _, name -> name.endsWith(".uid") } ?: emptyArray()
-                    val targetName = "$bestHexUid.uid"
-                    var targetExists = false
-                    for (f in uidFiles) {
-                        if (f.name.equals(targetName, ignoreCase = true)) {
-                            targetExists = true
-                        } else {
-                            f.delete()
-                        }
-                    }
-                    if (!targetExists) {
-                        dir.resolve(targetName).createNewFile()
+                // If no bestHexUid found from existing tables, check if there is an existing .uid file in dir
+                if (bestHexUid.isNullOrEmpty()) {
+                    val existingUidFile = dir.listFiles { _, name -> name.endsWith(".uid") }?.firstOrNull()
+                    if (existingUidFile != null) {
+                        bestHexUid = existingUidFile.name.removeSuffix(".uid")
+                    } else {
+                        // Generate a valid 16-hex-digit UID
+                        bestHexUid = java.lang.Long.toHexString(java.security.SecureRandom().nextLong())
                     }
                 }
+
+                val targetTable = "ExoPlayerCacheIndex$bestHexUid"
+                try {
+                    db.execSQL(
+                        "CREATE TABLE IF NOT EXISTS $targetTable (" +
+                        "id INTEGER PRIMARY KEY NOT NULL, " +
+                        "key TEXT NOT NULL, " +
+                        "metadata BLOB NOT NULL)"
+                    )
+                } catch (_: Exception) {}
+
+                // Register version = 1 for this instance_uid so ExoPlayer won't drop the table on startup!
+                try {
+                    db.execSQL(
+                        "INSERT OR REPLACE INTO ExoPlayerVersions (feature, instance_uid, version) VALUES (1, '$bestHexUid', 1)"
+                    )
+                } catch (_: Exception) {}
+
+                // If table is missing entries for any of our chunkIds, populate them so ExoPlayer never deletes .exo files!
+                if (chunkIds.isNotEmpty()) {
+                    val existingIds = mutableSetOf<Int>()
+                    try {
+                        db.rawQuery("SELECT id FROM $targetTable", null).use { c ->
+                            while (c.moveToNext()) {
+                                existingIds.add(c.getInt(0))
+                            }
+                        }
+                    } catch (_: Exception) {}
+
+                    val missingIds = chunkIds.filter { !existingIds.contains(it) }.sorted()
+                    if (missingIds.isNotEmpty()) {
+                        val restoredSongs = mutableListOf<String>()
+                        try {
+                            val restoredFile = context.filesDir.resolve("restored_cache_ids.json")
+                            if (restoredFile.exists()) {
+                                val jsonArr = org.json.JSONArray(restoredFile.readText())
+                                for (i in 0 until jsonArr.length()) {
+                                    restoredSongs.add(jsonArr.getString(i))
+                                }
+                            }
+                        } catch (_: Exception) {}
+
+                        if (restoredSongs.isEmpty()) {
+                            val airbeatsDb = context.getDatabasePath("airbeats.db")
+                            if (airbeatsDb.exists()) {
+                                try {
+                                    android.database.sqlite.SQLiteDatabase.openDatabase(
+                                        airbeatsDb.path, null, android.database.sqlite.SQLiteDatabase.OPEN_READONLY
+                                    ).use { rdb ->
+                                        rdb.rawQuery("SELECT id FROM song", null).use { sc ->
+                                            while (sc.moveToNext()) {
+                                                restoredSongs.add(sc.getString(0))
+                                            }
+                                        }
+                                    }
+                                } catch (_: Exception) {}
+                            }
+                        }
+
+                        val emptyMetadata = byteArrayOf(0, 0, 0, 0)
+                        for (idx in missingIds.indices) {
+                            val chunkId = missingIds[idx]
+                            val songKey = restoredSongs.getOrNull(idx) ?: restoredSongs.getOrNull(chunkId) ?: "restored_$chunkId"
+                            try {
+                                val statement = db.compileStatement(
+                                    "INSERT OR IGNORE INTO $targetTable (id, key, metadata) VALUES (?, ?, ?)"
+                                )
+                                statement.bindLong(1, chunkId.toLong())
+                                statement.bindString(2, songKey)
+                                statement.bindBlob(3, emptyMetadata)
+                                statement.executeInsert()
+                            } catch (_: Exception) {}
+                        }
+                    }
+                }
+
+                // Ensure the dir has matching <bestHexUid>.uid and delete other .uid files
+                val uidFiles = dir.listFiles { _, name -> name.endsWith(".uid") } ?: emptyArray()
+                val targetName = "$bestHexUid.uid"
+                var targetExists = false
+                for (f in uidFiles) {
+                    if (f.name.equals(targetName, ignoreCase = true)) {
+                        targetExists = true
+                    } else {
+                        f.delete()
+                    }
+                }
+                if (!targetExists) {
+                    dir.resolve(targetName).createNewFile()
+                }
+
+                try {
+                    db.rawQuery("PRAGMA wal_checkpoint(FULL)", null).use { it.moveToFirst() }
+                } catch (_: Exception) {}
             }
         } catch (_: Exception) {}
     }

--- a/app/src/main/java/com/darkxvenom/airbeats/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/playback/DownloadUtil.kt
@@ -19,6 +19,7 @@ import com.darkxvenom.airbeats.db.MusicDatabase
 import com.darkxvenom.airbeats.db.entities.FormatEntity
 import com.darkxvenom.airbeats.di.DownloadCache
 import com.darkxvenom.airbeats.di.PlayerCache
+import com.darkxvenom.airbeats.extensions.tryOrNull
 import com.darkxvenom.airbeats.utils.YTPlayerUtils
 import com.darkxvenom.airbeats.utils.enumPreference
 import dagger.hilt.android.qualifiers.ApplicationContext

--- a/app/src/main/java/com/darkxvenom/airbeats/playback/DownloadUtil.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/playback/DownloadUtil.kt
@@ -62,9 +62,13 @@ constructor(
                 ),
         ) { dataSpec ->
             val mediaId = dataSpec.key ?: error("No media id")
-            val length = if (dataSpec.length >= 0) dataSpec.length else 1
+            val length = if (dataSpec.length >= 0) dataSpec.length else 1L
 
-            if (playerCache.isCached(mediaId, dataSpec.position, length)) {
+            if (playerCache.isCached(mediaId, dataSpec.position, length) ||
+                playerCache.isCached(mediaId, dataSpec.position, 1L) ||
+                (tryOrNull { playerCache.getCachedBytes(mediaId, dataSpec.position, 1L) } ?: 0L) > 0L ||
+                (tryOrNull { playerCache.getCachedBytes(mediaId, 0L, Long.MAX_VALUE) } ?: 0L) > 0L
+            ) {
                 return@Factory dataSpec
             }
 

--- a/app/src/main/java/com/darkxvenom/airbeats/playback/MusicService.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/playback/MusicService.kt
@@ -91,6 +91,7 @@ import com.darkxvenom.airbeats.constants.RepeatModeKey
 import com.darkxvenom.airbeats.constants.ShowLyricsKey
 import com.darkxvenom.airbeats.constants.SimilarContent
 import com.darkxvenom.airbeats.constants.SkipSilenceKey
+import com.darkxvenom.airbeats.constants.SkipUncachedPartKey
 import com.darkxvenom.airbeats.constants.StopMusicOnTaskClearKey
 import com.darkxvenom.airbeats.db.MusicDatabase
 import com.darkxvenom.airbeats.db.entities.Event
@@ -289,6 +290,7 @@ class MusicService :
     val automixItems = MutableStateFlow<List<MediaItem>>(emptyList())
 
     private var consecutivePlaybackErr = 0
+    private var offlineBufferingJob: Job? = null
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate() {
@@ -1310,6 +1312,22 @@ class MusicService :
         setupEqualizer()
 
         discordUpdateJob?.cancel()
+        offlineBufferingJob?.cancel()
+
+        // If offline and skip uncached is enabled, verify the track is cached
+        if (!isNetworkConnected.value && dataStore.get(SkipUncachedPartKey, false)) {
+            val mediaId = mediaItem?.mediaId
+            if (mediaId != null &&
+                !downloadCache.isCached(mediaId, 0, 1) &&
+                !playerCache.isCached(mediaId, 0, 1)
+            ) {
+                Log.i(TAG, "Song $mediaId is uncached while offline with SkipUncachedPart enabled. Skipping.")
+                scope.launch(Dispatchers.Main) {
+                    skipOnError()
+                }
+                return
+            }
+        }
 
         // Resetear errores consecutivos cuando hay transición exitosa
         consecutivePlaybackErr = 0
@@ -1342,6 +1360,18 @@ class MusicService :
     override fun onPlaybackStateChanged(
         @Player.State playbackState: Int,
     ) {
+        offlineBufferingJob?.cancel()
+        if (playbackState == Player.STATE_BUFFERING) {
+            if (!isNetworkConnected.value && dataStore.get(SkipUncachedPartKey, false)) {
+                offlineBufferingJob = scope.launch {
+                    delay(1200)
+                    if (player.playbackState == Player.STATE_BUFFERING && !isNetworkConnected.value) {
+                        Log.i(TAG, "Playback stalled buffering offline with SkipUncachedPart enabled. Skipping song.")
+                        skipOnError()
+                    }
+                }
+            }
+        }
         // Guardar estado cuando cambia el estado de reproducción
         if (dataStore.get(PersistentQueueKey, true) && playbackState != Player.STATE_BUFFERING) {
             scope.launch {
@@ -1488,6 +1518,11 @@ class MusicService :
                 (error.cause?.cause as PlaybackException).errorCode == PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED
 
         if (!isNetworkConnected.value || isConnectionError) {
+            if (dataStore.get(SkipUncachedPartKey, false)) {
+                Log.i(TAG, "Player network error while offline with SkipUncachedPart enabled. Skipping to next song.")
+                skipOnError()
+                return
+            }
             waitOnNetworkError()
             return
         }

--- a/app/src/main/java/com/darkxvenom/airbeats/playback/MusicService.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/playback/MusicService.kt
@@ -100,6 +100,7 @@ import com.darkxvenom.airbeats.db.entities.LyricsEntity
 import com.darkxvenom.airbeats.db.entities.RelatedSongMap
 import com.darkxvenom.airbeats.di.DownloadCache
 import com.darkxvenom.airbeats.di.PlayerCache
+import com.darkxvenom.airbeats.extensions.tryOrNull
 import com.darkxvenom.airbeats.extensions.SilentHandler
 import com.darkxvenom.airbeats.extensions.collect
 import com.darkxvenom.airbeats.extensions.collectLatest

--- a/app/src/main/java/com/darkxvenom/airbeats/playback/MusicService.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/playback/MusicService.kt
@@ -1317,10 +1317,12 @@ class MusicService :
         // If offline and skip uncached is enabled, verify the track is cached
         if (!isNetworkConnected.value && dataStore.get(SkipUncachedPartKey, false)) {
             val mediaId = mediaItem?.mediaId
-            if (mediaId != null &&
-                !downloadCache.isCached(mediaId, 0, 1) &&
-                !playerCache.isCached(mediaId, 0, 1)
-            ) {
+            val isSongCached = mediaId != null && (
+                downloadCache.isCached(mediaId, 0, 1) ||
+                playerCache.isCached(mediaId, 0, 1) ||
+                (tryOrNull { playerCache.getCachedBytes(mediaId, 0, Long.MAX_VALUE) } ?: 0L) > 0L
+            )
+            if (mediaId != null && !isSongCached) {
                 Log.i(TAG, "Song $mediaId is uncached while offline with SkipUncachedPart enabled. Skipping.")
                 scope.launch(Dispatchers.Main) {
                     skipOnError()
@@ -1589,13 +1591,14 @@ class MusicService :
             
             val mediaId = dataSpec.key ?: error("No media id")
 
-            if (downloadCache.isCached(
-                    mediaId,
-                    dataSpec.position,
-                    if (dataSpec.length >= 0) dataSpec.length else 1
-                ) ||
-                playerCache.isCached(mediaId, dataSpec.position, CHUNK_LENGTH)
-            ) {
+            val checkLength = if (dataSpec.length > 0) dataSpec.length.coerceAtMost(CHUNK_LENGTH) else 1L
+            val isCached = downloadCache.isCached(mediaId, dataSpec.position, if (dataSpec.length >= 0) dataSpec.length else 1L) ||
+                playerCache.isCached(mediaId, dataSpec.position, checkLength) ||
+                playerCache.isCached(mediaId, dataSpec.position, 1L) ||
+                (tryOrNull { playerCache.getCachedBytes(mediaId, dataSpec.position, 1L) } ?: 0L) > 0L ||
+                (tryOrNull { playerCache.getCachedBytes(mediaId, 0L, Long.MAX_VALUE) } ?: 0L) > 0L
+
+            if (isCached) {
                 scope.launch(Dispatchers.IO) { recoverSong(mediaId) }
                 return@Factory dataSpec
             }

--- a/app/src/main/java/com/darkxvenom/airbeats/playback/queues/YouTubeAlbumRadio.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/playback/queues/YouTubeAlbumRadio.kt
@@ -27,7 +27,7 @@ class YouTubeAlbumRadio(
         val albumSongs = YouTube.albumSongs(playlistId).getOrThrow()
         albumSongCount = albumSongs.size
         Queue.Status(
-            title = albumSongs.first().album?.name.orEmpty(),
+            title = albumSongs.firstOrNull()?.album?.name.orEmpty(),
             items = albumSongs.map { it.toMediaItem() },
             mediaItemIndex = 0
         )

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/component/LiquidGlassBottomBar.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/component/LiquidGlassBottomBar.kt
@@ -50,6 +50,7 @@ fun LiquidGlassBottomNavigationBar(
     onItemSelected: (Int) -> Unit,
     backdrop: PlatformBackdrop
 ) {
+    if (items.isEmpty()) return
     val layer = rememberGraphicsLayer()
     val luminanceAnimation = remember { Animatable(0.3f) }
 

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/menu/OnlinePlaylistAdder.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/menu/OnlinePlaylistAdder.kt
@@ -135,22 +135,20 @@ fun OnlinePlaylistAdder(
                                     try {
                                         YouTube.search(query, YouTube.SearchFilter.FILTER_SONG)
                                             .onSuccess { result ->
-                                                viewStateMap[YouTube.SearchFilter.FILTER_SONG.value] =
-                                                    ItemsPage(result.items.distinctBy { it.id }, result.continuation)
-                                                val itemsPage = viewStateMap.entries.first().value!!
-                                                val firstSong = itemsPage.items[0] as SongItem
-                                                val firstSongMedia = firstSong.toMediaMetadata()
-                                                val ids = List(1) {firstSong.id}
-                                                withContext(Dispatchers.IO) {
-                                                    try {
-                                                        database.insert(firstSongMedia)
-                                                    } catch (e: Exception) {
-                                                        Timber.tag("Exception inserting song in database:")
-                                                            .e(e.toString())
+                                                val firstSong = result.items.filterIsInstance<SongItem>().firstOrNull()
+                                                if (firstSong != null) {
+                                                    val firstSongMedia = firstSong.toMediaMetadata()
+                                                    val ids = listOf(firstSong.id)
+                                                    withContext(Dispatchers.IO) {
+                                                        try {
+                                                            database.insert(firstSongMedia)
+                                                        } catch (e: Exception) {
+                                                            Timber.tag("Exception inserting song in database:")
+                                                                .e(e.toString())
+                                                        }
+                                                        database.addSongToPlaylist(playlist, ids)
                                                     }
-                                                    database.addSongToPlaylist(playlist, ids)
                                                 }
-                                                viewStateMap.clear()
                                                 songsIdx += 1
                                             }
                                             .onFailure {
@@ -197,24 +195,22 @@ fun OnlinePlaylistAdder(
                                     try {
                                         YouTube.search(query, YouTube.SearchFilter.FILTER_SONG)
                                             .onSuccess { result ->
-                                                viewStateMap[YouTube.SearchFilter.FILTER_SONG.value] =
-                                                    ItemsPage(result.items.distinctBy { it.id }, result.continuation)
-                                                val itemsPage = viewStateMap.entries.first().value!!
-                                                val firstSong = itemsPage.items[0] as SongItem
-                                                val firstSongMedia = firstSong.toMediaMetadata()
-                                                val firstSongEnt = firstSong.toMediaMetadata().toSongEntity()
-                                                withContext(Dispatchers.IO) {
-                                                    try {
-                                                        database.insert(firstSongMedia)
-                                                        database.query {
-                                                            update(firstSongEnt.toggleLike())
+                                                val firstSong = result.items.filterIsInstance<SongItem>().firstOrNull()
+                                                if (firstSong != null) {
+                                                    val firstSongMedia = firstSong.toMediaMetadata()
+                                                    val firstSongEnt = firstSong.toMediaMetadata().toSongEntity()
+                                                    withContext(Dispatchers.IO) {
+                                                        try {
+                                                            database.insert(firstSongMedia)
+                                                            database.query {
+                                                                update(firstSongEnt.toggleLike())
+                                                            }
+                                                        } catch (e: Exception) {
+                                                            Timber.tag("Exception inserting song in database:")
+                                                                .e(e.toString())
                                                         }
-                                                    } catch (e: Exception) {
-                                                        Timber.tag("Exception inserting song in database:")
-                                                            .e(e.toString())
                                                     }
                                                 }
-                                                viewStateMap.clear()
                                                 songsIdx += 1
                                             }
                                             .onFailure {

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/library/CachePlaylistScreen.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/library/CachePlaylistScreen.kt
@@ -117,16 +117,22 @@ fun CachePlaylistScreen(
     val isPlaying by playerConnection.isPlaying.collectAsState()
     val mediaMetadata by playerConnection.mediaMetadata.collectAsState()
     val events by viewModel.events.collectAsState()
+    val dbSongs by viewModel.database.allSongs().collectAsState(initial = emptyList())
 
-    val playerCache = LocalPlayerConnection.current?.service?.playerCache
+    val service = LocalPlayerConnection.current?.service
+    val playerCache = service?.playerCache
+    val downloadCache = service?.downloadCache
 
-    val cachedSongIds = remember(playerCache) {
-        playerCache?.keys?.mapNotNull { it.toString() }?.toSet() ?: emptySet()
+    val cachedSongIds = remember(playerCache, downloadCache) {
+        val keys = mutableSetOf<String>()
+        playerCache?.keys?.mapNotNullTo(keys) { it.toString() }
+        downloadCache?.keys?.mapNotNullTo(keys) { it.toString() }
+        keys.toSet()
     }
 
-    val allSongs = remember(events, cachedSongIds) {
-        events.values.flatten()
-            .map { it.song }
+    val allSongs = remember(events, dbSongs, cachedSongIds) {
+        val historySongs = events.values.flatten().map { it.song }
+        (historySongs + dbSongs)
             .distinctBy { it.id }
             .filter { it.id in cachedSongIds }
     }

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/library/CachePlaylistScreen.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/library/CachePlaylistScreen.kt
@@ -1,5 +1,7 @@
 package com.darkxvenom.airbeats.ui.screens.library
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -87,7 +89,10 @@ import com.darkxvenom.airbeats.ui.menu.SelectionSongMenu
 import com.darkxvenom.airbeats.ui.menu.SongMenu
 import com.darkxvenom.airbeats.ui.utils.ItemWrapper
 import com.darkxvenom.airbeats.ui.utils.backToMain
+import com.darkxvenom.airbeats.viewmodels.BackupRestoreViewModel
 import com.darkxvenom.airbeats.viewmodels.HistoryViewModel
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -95,8 +100,15 @@ fun CachePlaylistScreen(
     navController: NavController,
     scrollBehavior: TopAppBarScrollBehavior,
     viewModel: HistoryViewModel = hiltViewModel(),
+    backupViewModel: BackupRestoreViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
+    val backupCacheLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/zip")) { uri ->
+            if (uri != null) {
+                backupViewModel.backupCache(context, uri)
+            }
+        }
     val menuState = LocalMenuState.current
     val playerConnection = LocalPlayerConnection.current ?: return
     val haptic = LocalHapticFeedback.current
@@ -329,7 +341,7 @@ fun CachePlaylistScreen(
                                         .clip(RoundedCornerShape(ThumbnailCornerRadius))
                                 ) {
                                     AsyncImage(
-                                        model = filteredSongs.first().item.thumbnailUrl,
+                                        model = filteredSongs.firstOrNull()?.item?.thumbnailUrl,
                                         contentDescription = null,
                                         modifier = Modifier
                                             .fillMaxWidth()
@@ -573,6 +585,17 @@ fun CachePlaylistScreen(
                         )
                     }
                 } else if (!isSearching) {
+                    IconButton(onClick = {
+                        val formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+                        backupCacheLauncher.launch(
+                            "AirBeats_Cache_${LocalDateTime.now().format(formatter)}.airbeatscache"
+                        )
+                    }) {
+                        Icon(
+                            painter = painterResource(R.drawable.backup),
+                            contentDescription = stringResource(R.string.backup_cached_songs)
+                        )
+                    }
                     IconButton(onClick = { isSearching = true }) {
                         Icon(
                             painter = painterResource(R.drawable.search),

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/library/CachePlaylistScreen.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/library/CachePlaylistScreen.kt
@@ -80,6 +80,7 @@ import com.darkxvenom.airbeats.constants.ThumbnailCornerRadius
 import com.darkxvenom.airbeats.db.entities.Song
 import com.darkxvenom.airbeats.extensions.toMediaItem
 import com.darkxvenom.airbeats.extensions.togglePlayPause
+import com.darkxvenom.airbeats.extensions.tryOrNull
 import com.darkxvenom.airbeats.playback.queues.ListQueue
 import com.darkxvenom.airbeats.ui.component.EmptyPlaceholder
 import com.darkxvenom.airbeats.ui.component.IconButton
@@ -91,6 +92,8 @@ import com.darkxvenom.airbeats.ui.utils.ItemWrapper
 import com.darkxvenom.airbeats.ui.utils.backToMain
 import com.darkxvenom.airbeats.viewmodels.BackupRestoreViewModel
 import com.darkxvenom.airbeats.viewmodels.HistoryViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
@@ -123,11 +126,41 @@ fun CachePlaylistScreen(
     val playerCache = service?.playerCache
     val downloadCache = service?.downloadCache
 
-    val cachedSongIds = remember(playerCache, downloadCache) {
-        val keys = mutableSetOf<String>()
-        playerCache?.keys?.mapNotNullTo(keys) { it.toString() }
-        downloadCache?.keys?.mapNotNullTo(keys) { it.toString() }
-        keys.toSet()
+    val restoredCacheIds = remember {
+        runCatching {
+            val file = context.filesDir.resolve("restored_cache_ids.json")
+            if (file.exists()) {
+                val json = org.json.JSONArray(file.readText())
+                val set = mutableSetOf<String>()
+                for (i in 0 until json.length()) {
+                    set.add(json.getString(i))
+                }
+                set
+            } else emptySet()
+        }.getOrDefault(emptySet())
+    }
+
+    var cachedSongIds by remember {
+        mutableStateOf(
+            buildSet {
+                addAll(restoredCacheIds)
+                tryOrNull { playerCache?.keys }?.mapNotNullTo(this) { it.toString() }
+                tryOrNull { downloadCache?.keys }?.mapNotNullTo(this) { it.toString() }
+            }
+        )
+    }
+
+    LaunchedEffect(playerCache, downloadCache) {
+        while (isActive) {
+            val keys = mutableSetOf<String>()
+            keys.addAll(restoredCacheIds)
+            tryOrNull { playerCache?.keys }?.mapNotNullTo(keys) { it.toString() }
+            tryOrNull { downloadCache?.keys }?.mapNotNullTo(keys) { it.toString() }
+            if (keys != cachedSongIds) {
+                cachedSongIds = keys.toSet()
+            }
+            delay(1000)
+        }
     }
 
     val allSongs = remember(events, dbSongs, cachedSongIds) {

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/AboutScreen.kt
@@ -700,7 +700,7 @@ fun AboutScreen(
                             role = "UI/UX Specialist",
                             commits = founderCommits["drkvenom786"],
                             githubUrl = "https://github.com/drkvenom786",
-                            websiteUrl = "https://venomx.pro",
+                            websiteUrl = "https://drkvenom786.github.io/webpage/",
                             modifier = Modifier.weight(1f),
                             onClick = { navController.navigate("contributor/drkvenom786") }
                         )

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/BackupAndRestore.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/BackupAndRestore.kt
@@ -184,6 +184,20 @@ fun BackupAndRestore(
             }
         }
 
+    val backupCacheLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/zip")) { uri ->
+            if (uri != null) {
+                viewModel.backupCache(context, uri)
+            }
+        }
+
+    val restoreCacheLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            if (uri != null) {
+                viewModel.restoreCache(context, uri)
+            }
+        }
+
     val importPlaylistFromCsv =
         rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
             if (uri == null) return@rememberLauncherForActivityResult
@@ -269,6 +283,27 @@ fun BackupAndRestore(
                     isEnabled = uploadStatus !is UploadStatus.Uploading,
                     onClick = {
                         restoreLauncher.launch(arrayOf("application/octet-stream"))
+                    }
+                )},
+                {PreferenceEntry(
+                    title = { Text(stringResource(R.string.backup_cached_songs)) },
+                    icon = { Icon(painterResource(R.drawable.cached), null) },
+                    description = stringResource(R.string.backup_cached_songs_desc),
+                    isEnabled = uploadStatus !is UploadStatus.Uploading,
+                    onClick = {
+                        val formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmmss")
+                        backupCacheLauncher.launch(
+                            "AirBeats_Cache_${LocalDateTime.now().format(formatter)}.airbeatscache"
+                        )
+                    }
+                )},
+                {PreferenceEntry(
+                    title = { Text(stringResource(R.string.restore_cached_songs)) },
+                    icon = { Icon(painterResource(R.drawable.restore), null) },
+                    description = stringResource(R.string.restore_cached_songs_desc),
+                    isEnabled = uploadStatus !is UploadStatus.Uploading,
+                    onClick = {
+                        restoreCacheLauncher.launch(arrayOf("application/zip", "application/octet-stream", "*/*"))
                     }
                 )},
                 {AnimatedVisibility(

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/PlayerSettings.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/PlayerSettings.kt
@@ -29,6 +29,7 @@ import com.darkxvenom.airbeats.constants.CrossfadeKey
 import com.darkxvenom.airbeats.constants.PersistentQueueKey
 import com.darkxvenom.airbeats.constants.SimilarContent
 import com.darkxvenom.airbeats.constants.SkipSilenceKey
+import com.darkxvenom.airbeats.constants.SkipUncachedPartKey
 import com.darkxvenom.airbeats.constants.StopMusicOnTaskClearKey
 import com.darkxvenom.airbeats.ui.component.EnumListPreference
 import com.darkxvenom.airbeats.ui.component.IconButton
@@ -80,6 +81,10 @@ fun PlayerSettings(
     )
     val (autoSkipNextOnError, onAutoSkipNextOnErrorChange) = rememberPreference(
         AutoSkipNextOnErrorKey,
+        defaultValue = false
+    )
+    val (skipUncachedPart, onSkipUncachedPartChange) = rememberPreference(
+        SkipUncachedPartKey,
         defaultValue = false
     )
     val (stopMusicOnTaskClear, onStopMusicOnTaskClearChange) = rememberPreference(
@@ -183,6 +188,14 @@ fun PlayerSettings(
                     icon = { Icon(painterResource(R.drawable.skip_next), null) },
                     checked = autoSkipNextOnError,
                     onCheckedChange = onAutoSkipNextOnErrorChange
+                )},
+
+                {SwitchPreference(
+                    title = { Text(stringResource(R.string.skip_uncached_part)) },
+                    description = stringResource(R.string.skip_uncached_part_desc),
+                    icon = { Icon(painterResource(R.drawable.cached), null) },
+                    checked = skipUncachedPart,
+                    onCheckedChange = onSkipUncachedPartChange
                 )},
             )
         )

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/StorageSettings.kt
@@ -441,6 +441,7 @@ private fun CachedSongsBottomSheet(
     viewModel: HistoryViewModel,
     onDismiss: () -> Unit
 ) {
+    val context = LocalContext.current
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val coroutineScope = rememberCoroutineScope()
     val events by viewModel.events.collectAsState()

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/StorageSettings.kt
@@ -443,16 +443,17 @@ private fun CachedSongsBottomSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val coroutineScope = rememberCoroutineScope()
     val events by viewModel.events.collectAsState()
+    val dbSongs by viewModel.database.allSongs().collectAsState(initial = emptyList())
 
     // Obtener IDs de canciones en caché
     val cachedSongIds = remember(playerCache) {
         playerCache.keys.map { it.toString() }.toSet()
     }
 
-    // Obtener canciones completas desde el historial (similar a CachePlaylistScreen)
-    val cachedSongs = remember(events, cachedSongIds) {
-        events.values.flatten()
-            .map { it.song }
+    // Obtener canciones completas desde el historial y base de datos
+    val cachedSongs = remember(events, dbSongs, cachedSongIds) {
+        val historySongs = events.values.flatten().map { it.song }
+        (historySongs + dbSongs)
             .distinctBy { it.id }
             .filter { it.id in cachedSongIds }
     }

--- a/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/StorageSettings.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/ui/screens/settings/StorageSettings.kt
@@ -180,6 +180,7 @@ fun StorageSettings(
                             playerCache.keys.toList().forEach { key ->
                                 tryOrNull { playerCache.removeResource(key) }
                             }
+                            context.filesDir.resolve("restored_cache_ids.json").delete()
                         } catch (e: Exception) {
                             e.printStackTrace()
                         }
@@ -445,9 +446,40 @@ private fun CachedSongsBottomSheet(
     val events by viewModel.events.collectAsState()
     val dbSongs by viewModel.database.allSongs().collectAsState(initial = emptyList())
 
+    val restoredCacheIds = remember {
+        runCatching {
+            val file = context.filesDir.resolve("restored_cache_ids.json")
+            if (file.exists()) {
+                val json = org.json.JSONArray(file.readText())
+                val set = mutableSetOf<String>()
+                for (i in 0 until json.length()) {
+                    set.add(json.getString(i))
+                }
+                set
+            } else emptySet()
+        }.getOrDefault(emptySet())
+    }
+
     // Obtener IDs de canciones en caché
-    val cachedSongIds = remember(playerCache) {
-        playerCache.keys.map { it.toString() }.toSet()
+    var cachedSongIds by remember {
+        mutableStateOf(
+            buildSet {
+                addAll(restoredCacheIds)
+                tryOrNull { playerCache.keys }?.mapNotNullTo(this) { it.toString() }
+            }
+        )
+    }
+
+    LaunchedEffect(playerCache) {
+        while (isActive) {
+            val keys = mutableSetOf<String>()
+            keys.addAll(restoredCacheIds)
+            tryOrNull { playerCache.keys }?.mapNotNullTo(keys) { it.toString() }
+            if (keys != cachedSongIds) {
+                cachedSongIds = keys.toSet()
+            }
+            delay(1000)
+        }
     }
 
     // Obtener canciones completas desde el historial y base de datos
@@ -465,7 +497,7 @@ private fun CachedSongsBottomSheet(
                 playerCache.getCachedBytes(song.id, 0, Long.MAX_VALUE)
             } ?: 0L
 
-            if (size > 0) {
+            if (size > 0 || song.id in restoredCacheIds) {
                 CachedSongInfo(song = song, size = size)
             } else null
         }.sortedByDescending { it.size }

--- a/app/src/main/java/com/darkxvenom/airbeats/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/viewmodels/BackupRestoreViewModel.kt
@@ -5,13 +5,19 @@ import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.darkxvenom.airbeats.MainActivity
 import com.darkxvenom.airbeats.R
 import com.darkxvenom.airbeats.db.InternalDatabase
 import com.darkxvenom.airbeats.db.MusicDatabase
 import com.darkxvenom.airbeats.db.entities.ArtistEntity
+import com.darkxvenom.airbeats.db.entities.FormatEntity
 import com.darkxvenom.airbeats.db.entities.Song
 import com.darkxvenom.airbeats.db.entities.SongEntity
+import com.darkxvenom.airbeats.models.MediaMetadata
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
 import com.darkxvenom.airbeats.extensions.div
 import com.darkxvenom.airbeats.extensions.tryOrNull
 import com.darkxvenom.airbeats.extensions.zipInputStream
@@ -346,7 +352,7 @@ class BackupRestoreViewModel @Inject constructor(
         runCatching {
             context.applicationContext.contentResolver.openInputStream(uri)?.use { stream ->
                 val lines = stream.bufferedReader().readLines()
-                if (lines.first().startsWith("#EXTM3U")) {
+                if (lines.firstOrNull()?.startsWith("#EXTM3U") == true) {
                     lines.forEachIndexed { _, rawLine ->
                         if (rawLine.startsWith("#EXTINF:")) {
                             // maybe later write this to be more efficient
@@ -406,6 +412,196 @@ class BackupRestoreViewModel @Inject constructor(
         }.onFailure {
             reportException(it)
             Toast.makeText(context, "Error al resetear VISITOR_DATA", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    fun backupCache(context: Context, uri: Uri) {
+        viewModelScope.launch(Dispatchers.IO) {
+            runCatching {
+                database.checkpoint()
+                context.applicationContext.contentResolver.openOutputStream(uri)?.use { stream ->
+                    stream.buffered().zipOutputStream().use { zipOut ->
+                        // 1. Backup exoplayer cache chunks
+                        val exoDir = context.filesDir.resolve("exoplayer")
+                        if (exoDir.exists() && exoDir.isDirectory) {
+                            exoDir.walkTopDown().forEach { file ->
+                                if (file.isFile) {
+                                    val relPath = "exoplayer/" + file.relativeTo(exoDir).path.replace('\\', '/')
+                                    zipOut.putNextEntry(ZipEntry(relPath))
+                                    file.inputStream().buffered().use { it.copyTo(zipOut) }
+                                }
+                            }
+                        }
+
+                        // 2. Backup download cache if present
+                        val dlDir = context.filesDir.resolve("download")
+                        if (dlDir.exists() && dlDir.isDirectory) {
+                            dlDir.walkTopDown().forEach { file ->
+                                if (file.isFile) {
+                                    val relPath = "download/" + file.relativeTo(dlDir).path.replace('\\', '/')
+                                    zipOut.putNextEntry(ZipEntry(relPath))
+                                    file.inputStream().buffered().use { it.copyTo(zipOut) }
+                                }
+                            }
+                        }
+
+                        // 3. Backup exoplayer internal database
+                        val exoDb = context.getDatabasePath("exoplayer_internal.db")
+                        if (exoDb.exists() && exoDb.isFile) {
+                            zipOut.putNextEntry(ZipEntry("exoplayer_internal.db"))
+                            exoDb.inputStream().buffered().use { it.copyTo(zipOut) }
+                        }
+                        val exoDbWal = context.getDatabasePath("exoplayer_internal.db-wal")
+                        if (exoDbWal.exists() && exoDbWal.isFile) {
+                            zipOut.putNextEntry(ZipEntry("exoplayer_internal.db-wal"))
+                            exoDbWal.inputStream().buffered().use { it.copyTo(zipOut) }
+                        }
+
+                        // 4. Backup cached song metadata and formats
+                        val allSongs = runCatching { database.songsByNameAsc().first() }.getOrDefault(emptyList())
+                        val songJsonArray = JSONArray()
+                        for (song in allSongs) {
+                            val format = runCatching { database.format(song.id).first() }.getOrNull()
+                            val obj = JSONObject().apply {
+                                put("id", song.id)
+                                put("title", song.title)
+                                put("duration", song.duration)
+                                put("thumbnailUrl", song.thumbnailUrl)
+                                put("artists", JSONArray(song.artists.map { it.name }))
+                                if (format != null) {
+                                    put("itag", format.itag)
+                                    put("mimeType", format.mimeType)
+                                    put("codecs", format.codecs)
+                                    put("bitrate", format.bitrate)
+                                    put("sampleRate", format.sampleRate)
+                                    put("contentLength", format.contentLength)
+                                    if (format.loudnessDb != null) put("loudnessDb", format.loudnessDb)
+                                    if (format.playbackUrl != null) put("playbackUrl", format.playbackUrl)
+                                }
+                            }
+                            songJsonArray.put(obj)
+                        }
+                        zipOut.putNextEntry(ZipEntry("cached_songs_metadata.json"))
+                        zipOut.write(songJsonArray.toString().toByteArray(Charsets.UTF_8))
+                    }
+                }
+            }.onSuccess {
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, R.string.backup_cache_success, Toast.LENGTH_SHORT).show()
+                }
+            }.onFailure {
+                reportException(it)
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, R.string.backup_cache_failed, Toast.LENGTH_SHORT).show()
+                }
+            }
+        }
+    }
+
+    fun restoreCache(context: Context, uri: Uri) {
+        viewModelScope.launch(Dispatchers.IO) {
+            runCatching {
+                val exoDir = context.filesDir.resolve("exoplayer")
+                val dlDir = context.filesDir.resolve("download")
+                exoDir.mkdirs()
+                dlDir.mkdirs()
+
+                context.applicationContext.contentResolver.openInputStream(uri)?.use { stream ->
+                    stream.zipInputStream().use { zipIn ->
+                        var entry = tryOrNull { zipIn.nextEntry }
+                        while (entry != null) {
+                            val name = entry.name
+                            when {
+                                name.startsWith("exoplayer/") -> {
+                                    val rel = name.removePrefix("exoplayer/")
+                                    if (rel.isNotEmpty()) {
+                                        val target = exoDir.resolve(rel)
+                                        target.parentFile?.mkdirs()
+                                        target.outputStream().buffered().use { zipIn.copyTo(it) }
+                                    }
+                                }
+                                name.startsWith("download/") -> {
+                                    val rel = name.removePrefix("download/")
+                                    if (rel.isNotEmpty()) {
+                                        val target = dlDir.resolve(rel)
+                                        target.parentFile?.mkdirs()
+                                        target.outputStream().buffered().use { zipIn.copyTo(it) }
+                                    }
+                                }
+                                name == "exoplayer_internal.db" || name == "db/exoplayer_internal.db" -> {
+                                    val target = context.getDatabasePath("exoplayer_internal.db")
+                                    target.parentFile?.mkdirs()
+                                    target.outputStream().buffered().use { zipIn.copyTo(it) }
+                                }
+                                name == "exoplayer_internal.db-wal" || name == "db/exoplayer_internal.db-wal" -> {
+                                    val target = context.getDatabasePath("exoplayer_internal.db-wal")
+                                    target.parentFile?.mkdirs()
+                                    target.outputStream().buffered().use { zipIn.copyTo(it) }
+                                }
+                                name == "cached_songs_metadata.json" || name == "metadata.json" -> {
+                                    val jsonStr = zipIn.readBytes().toString(Charsets.UTF_8)
+                                    val array = JSONArray(jsonStr)
+                                    for (i in 0 until array.length()) {
+                                        val obj = array.getJSONObject(i)
+                                        val id = obj.getString("id")
+                                        val title = obj.getString("title")
+                                        val duration = obj.optInt("duration", -1)
+                                        val thumbnailUrl = if (obj.has("thumbnailUrl") && !obj.isNull("thumbnailUrl")) obj.getString("thumbnailUrl") else null
+                                        val artistsArray = obj.optJSONArray("artists")
+                                        val artists = mutableListOf<String>()
+                                        if (artistsArray != null) {
+                                            for (j in 0 until artistsArray.length()) {
+                                                artists.add(artistsArray.getString(j))
+                                            }
+                                        }
+                                        val mediaMetadata = MediaMetadata(
+                                            id = id,
+                                            title = title,
+                                            artists = artists.map { MediaMetadata.Artist(id = null, name = it) },
+                                            duration = duration,
+                                            thumbnailUrl = thumbnailUrl
+                                        )
+                                        database.insert(mediaMetadata)
+
+                                        if (obj.has("itag")) {
+                                            database.query {
+                                                upsert(
+                                                    FormatEntity(
+                                                        id = id,
+                                                        itag = obj.getInt("itag"),
+                                                        mimeType = obj.getString("mimeType"),
+                                                        codecs = obj.getString("codecs"),
+                                                        bitrate = obj.getInt("bitrate"),
+                                                        sampleRate = obj.getInt("sampleRate"),
+                                                        contentLength = obj.getLong("contentLength"),
+                                                        loudnessDb = if (obj.has("loudnessDb") && !obj.isNull("loudnessDb")) obj.getDouble("loudnessDb") else null,
+                                                        playbackUrl = if (obj.has("playbackUrl") && !obj.isNull("playbackUrl")) obj.getString("playbackUrl") else null
+                                                    )
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            entry = tryOrNull { zipIn.nextEntry }
+                        }
+                    }
+                }
+
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, R.string.restore_cache_success, Toast.LENGTH_SHORT).show()
+                    context.stopService(Intent(context, MusicService::class.java))
+                    context.startActivity(
+                        Intent(context, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    )
+                    exitProcess(0)
+                }
+            }.onFailure {
+                reportException(it)
+                withContext(Dispatchers.Main) {
+                    Toast.makeText(context, R.string.restore_cache_failed, Toast.LENGTH_SHORT).show()
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/darkxvenom/airbeats/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/viewmodels/BackupRestoreViewModel.kt
@@ -607,6 +607,12 @@ class BackupRestoreViewModel @Inject constructor(
                                         target.outputStream().buffered().use { zipIn.copyTo(it) }
                                     }
                                 }
+                                normName.endsWith(".exo") || normName.endsWith(".uid") -> {
+                                    val fileName = normName.substringAfterLast('/')
+                                    val target = exoDir.resolve(fileName)
+                                    target.parentFile?.mkdirs()
+                                    target.outputStream().buffered().use { zipIn.copyTo(it) }
+                                }
                                 normName == "exoplayer_internal.db" || normName.endsWith("/exoplayer_internal.db") -> {
                                     exoDb.parentFile?.mkdirs()
                                     exoDb.outputStream().buffered().use { zipIn.copyTo(it) }

--- a/app/src/main/java/com/darkxvenom/airbeats/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/viewmodels/BackupRestoreViewModel.kt
@@ -1,7 +1,10 @@
 package com.darkxvenom.airbeats.viewmodels
 
+import android.app.AlarmManager
+import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
+import android.database.sqlite.SQLiteDatabase
 import android.net.Uri
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
@@ -11,10 +14,12 @@ import com.darkxvenom.airbeats.R
 import com.darkxvenom.airbeats.db.InternalDatabase
 import com.darkxvenom.airbeats.db.MusicDatabase
 import com.darkxvenom.airbeats.db.entities.ArtistEntity
+import com.darkxvenom.airbeats.db.entities.Event
 import com.darkxvenom.airbeats.db.entities.FormatEntity
 import com.darkxvenom.airbeats.db.entities.Song
 import com.darkxvenom.airbeats.db.entities.SongEntity
 import com.darkxvenom.airbeats.models.MediaMetadata
+import java.time.LocalDateTime
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONArray
@@ -158,10 +163,8 @@ class BackupRestoreViewModel @Inject constructor(
                     }
                 }
             }
-            context.stopService(Intent(context, MusicService::class.java))
             context.filesDir.resolve(PERSISTENT_QUEUE_FILE).delete()
-            context.startActivity(Intent(context, MainActivity::class.java))
-            exitProcess(0)
+            restartApp(context)
         }.onFailure {
             reportException(it)
             Toast.makeText(context, R.string.restore_failed, Toast.LENGTH_SHORT).show()
@@ -415,10 +418,59 @@ class BackupRestoreViewModel @Inject constructor(
         }
     }
 
+    fun restartApp(context: Context) {
+        try {
+            context.stopService(Intent(context, MusicService::class.java))
+        } catch (_: Exception) {}
+
+        val packageManager = context.packageManager
+        val intent = packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+
+        if (intent != null) {
+            try {
+                val pendingIntent = PendingIntent.getActivity(
+                    context,
+                    24601,
+                    intent,
+                    PendingIntent.FLAG_CANCEL_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+                val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as? AlarmManager
+                alarmManager?.set(
+                    AlarmManager.RTC,
+                    System.currentTimeMillis() + 400,
+                    pendingIntent
+                )
+            } catch (_: Exception) {}
+            try {
+                context.startActivity(intent)
+            } catch (_: Exception) {}
+        }
+
+        try {
+            Thread.sleep(350)
+        } catch (_: InterruptedException) {}
+
+        android.os.Process.killProcess(android.os.Process.myPid())
+        exitProcess(0)
+    }
+
     fun backupCache(context: Context, uri: Uri) {
         viewModelScope.launch(Dispatchers.IO) {
             runCatching {
                 database.checkpoint()
+
+                // Checkpoint ExoPlayer internal DB so all cached spans in WAL are flushed to exoplayer_internal.db
+                val exoDbFile = context.getDatabasePath("exoplayer_internal.db")
+                if (exoDbFile.exists()) {
+                    tryOrNull {
+                        SQLiteDatabase.openDatabase(exoDbFile.path, null, SQLiteDatabase.OPEN_READWRITE).use { db ->
+                            db.rawQuery("PRAGMA wal_checkpoint(FULL)", null).use { it.moveToFirst() }
+                        }
+                    }
+                }
+
                 context.applicationContext.contentResolver.openOutputStream(uri)?.use { stream ->
                     stream.buffered().zipOutputStream().use { zipOut ->
                         // 1. Backup exoplayer cache chunks
@@ -429,6 +481,7 @@ class BackupRestoreViewModel @Inject constructor(
                                     val relPath = "exoplayer/" + file.relativeTo(exoDir).path.replace('\\', '/')
                                     zipOut.putNextEntry(ZipEntry(relPath))
                                     file.inputStream().buffered().use { it.copyTo(zipOut) }
+                                    zipOut.closeEntry()
                                 }
                             }
                         }
@@ -441,6 +494,7 @@ class BackupRestoreViewModel @Inject constructor(
                                     val relPath = "download/" + file.relativeTo(dlDir).path.replace('\\', '/')
                                     zipOut.putNextEntry(ZipEntry(relPath))
                                     file.inputStream().buffered().use { it.copyTo(zipOut) }
+                                    zipOut.closeEntry()
                                 }
                             }
                         }
@@ -450,11 +504,13 @@ class BackupRestoreViewModel @Inject constructor(
                         if (exoDb.exists() && exoDb.isFile) {
                             zipOut.putNextEntry(ZipEntry("exoplayer_internal.db"))
                             exoDb.inputStream().buffered().use { it.copyTo(zipOut) }
+                            zipOut.closeEntry()
                         }
                         val exoDbWal = context.getDatabasePath("exoplayer_internal.db-wal")
                         if (exoDbWal.exists() && exoDbWal.isFile) {
                             zipOut.putNextEntry(ZipEntry("exoplayer_internal.db-wal"))
                             exoDbWal.inputStream().buffered().use { it.copyTo(zipOut) }
+                            zipOut.closeEntry()
                         }
 
                         // 4. Backup cached song metadata and formats
@@ -483,6 +539,7 @@ class BackupRestoreViewModel @Inject constructor(
                         }
                         zipOut.putNextEntry(ZipEntry("cached_songs_metadata.json"))
                         zipOut.write(songJsonArray.toString().toByteArray(Charsets.UTF_8))
+                        zipOut.closeEntry()
                     }
                 }
             }.onSuccess {
@@ -501,10 +558,28 @@ class BackupRestoreViewModel @Inject constructor(
     fun restoreCache(context: Context, uri: Uri) {
         viewModelScope.launch(Dispatchers.IO) {
             runCatching {
+                // Stop playback service first so files and databases are released
+                withContext(Dispatchers.Main) {
+                    try {
+                        context.stopService(Intent(context, MusicService::class.java))
+                    } catch (_: Exception) {}
+                }
+
                 val exoDir = context.filesDir.resolve("exoplayer")
                 val dlDir = context.filesDir.resolve("download")
                 exoDir.mkdirs()
                 dlDir.mkdirs()
+
+                // Delete any existing internal exo db and journals to prevent SQLite lock or journal mismatch
+                val exoDb = context.getDatabasePath("exoplayer_internal.db")
+                val exoDbWal = context.getDatabasePath("exoplayer_internal.db-wal")
+                val exoDbShm = context.getDatabasePath("exoplayer_internal.db-shm")
+                val exoDbJournal = context.getDatabasePath("exoplayer_internal.db-journal")
+
+                exoDb.delete()
+                exoDbWal.delete()
+                exoDbShm.delete()
+                exoDbJournal.delete()
 
                 context.applicationContext.contentResolver.openInputStream(uri)?.use { stream ->
                     stream.zipInputStream().use { zipIn ->
@@ -528,17 +603,15 @@ class BackupRestoreViewModel @Inject constructor(
                                         target.outputStream().buffered().use { zipIn.copyTo(it) }
                                     }
                                 }
-                                name == "exoplayer_internal.db" || name == "db/exoplayer_internal.db" -> {
-                                    val target = context.getDatabasePath("exoplayer_internal.db")
-                                    target.parentFile?.mkdirs()
-                                    target.outputStream().buffered().use { zipIn.copyTo(it) }
+                                name == "exoplayer_internal.db" || name.endsWith("/exoplayer_internal.db") -> {
+                                    exoDb.parentFile?.mkdirs()
+                                    exoDb.outputStream().buffered().use { zipIn.copyTo(it) }
                                 }
-                                name == "exoplayer_internal.db-wal" || name == "db/exoplayer_internal.db-wal" -> {
-                                    val target = context.getDatabasePath("exoplayer_internal.db-wal")
-                                    target.parentFile?.mkdirs()
-                                    target.outputStream().buffered().use { zipIn.copyTo(it) }
+                                name == "exoplayer_internal.db-wal" || name.endsWith("/exoplayer_internal.db-wal") -> {
+                                    exoDbWal.parentFile?.mkdirs()
+                                    exoDbWal.outputStream().buffered().use { zipIn.copyTo(it) }
                                 }
-                                name == "cached_songs_metadata.json" || name == "metadata.json" -> {
+                                name == "cached_songs_metadata.json" || name.endsWith("/cached_songs_metadata.json") || name == "metadata.json" -> {
                                     val jsonStr = zipIn.readBytes().toString(Charsets.UTF_8)
                                     val array = JSONArray(jsonStr)
                                     for (i in 0 until array.length()) {
@@ -561,7 +634,27 @@ class BackupRestoreViewModel @Inject constructor(
                                             duration = duration,
                                             thumbnailUrl = thumbnailUrl
                                         )
-                                        database.insert(mediaMetadata)
+                                        database.query {
+                                            insert(mediaMetadata)
+                                            val existing = getSongById(id)
+                                            if (existing != null) {
+                                                update(existing.song.copy(
+                                                    title = title,
+                                                    duration = if (duration != -1) duration else existing.song.duration,
+                                                    thumbnailUrl = thumbnailUrl ?: existing.song.thumbnailUrl
+                                                ))
+                                            }
+                                            // Also record an Event so HistoryViewModel, CachePlaylistScreen, and StorageSettings immediately recognize it!
+                                            try {
+                                                insert(
+                                                    Event(
+                                                        songId = id,
+                                                        timestamp = LocalDateTime.now(),
+                                                        playTime = (duration.takeIf { it > 0 } ?: 180).toLong() * 1000L
+                                                    )
+                                                )
+                                            } catch (_: Exception) {}
+                                        }
 
                                         if (obj.has("itag")) {
                                             database.query {
@@ -588,13 +681,12 @@ class BackupRestoreViewModel @Inject constructor(
                     }
                 }
 
+                // Checkpoint database to flush restored entries
+                database.checkpoint()
+            }.onSuccess {
                 withContext(Dispatchers.Main) {
                     Toast.makeText(context, R.string.restore_cache_success, Toast.LENGTH_SHORT).show()
-                    context.stopService(Intent(context, MusicService::class.java))
-                    context.startActivity(
-                        Intent(context, MainActivity::class.java).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    )
-                    exitProcess(0)
+                    restartApp(context)
                 }
             }.onFailure {
                 reportException(it)

--- a/app/src/main/java/com/darkxvenom/airbeats/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/viewmodels/BackupRestoreViewModel.kt
@@ -567,6 +567,8 @@ class BackupRestoreViewModel @Inject constructor(
 
                 val exoDir = context.filesDir.resolve("exoplayer")
                 val dlDir = context.filesDir.resolve("download")
+                tryOrNull { exoDir.listFiles()?.forEach { it.deleteRecursively() } }
+                tryOrNull { dlDir.listFiles()?.forEach { it.deleteRecursively() } }
                 exoDir.mkdirs()
                 dlDir.mkdirs()
 
@@ -581,37 +583,39 @@ class BackupRestoreViewModel @Inject constructor(
                 exoDbShm.delete()
                 exoDbJournal.delete()
 
+                val restoredSongIds = mutableListOf<String>()
+
                 context.applicationContext.contentResolver.openInputStream(uri)?.use { stream ->
                     stream.zipInputStream().use { zipIn ->
                         var entry = tryOrNull { zipIn.nextEntry }
                         while (entry != null) {
-                            val name = entry.name
+                            val normName = entry.name.replace('\\', '/').trimStart('/')
                             when {
-                                name.startsWith("exoplayer/") -> {
-                                    val rel = name.removePrefix("exoplayer/")
+                                normName.startsWith("exoplayer/") || normName.startsWith("files/exoplayer/") -> {
+                                    val rel = normName.removePrefix("files/exoplayer/").removePrefix("exoplayer/")
                                     if (rel.isNotEmpty()) {
                                         val target = exoDir.resolve(rel)
                                         target.parentFile?.mkdirs()
                                         target.outputStream().buffered().use { zipIn.copyTo(it) }
                                     }
                                 }
-                                name.startsWith("download/") -> {
-                                    val rel = name.removePrefix("download/")
+                                normName.startsWith("download/") || normName.startsWith("files/download/") -> {
+                                    val rel = normName.removePrefix("files/download/").removePrefix("download/")
                                     if (rel.isNotEmpty()) {
                                         val target = dlDir.resolve(rel)
                                         target.parentFile?.mkdirs()
                                         target.outputStream().buffered().use { zipIn.copyTo(it) }
                                     }
                                 }
-                                name == "exoplayer_internal.db" || name.endsWith("/exoplayer_internal.db") -> {
+                                normName == "exoplayer_internal.db" || normName.endsWith("/exoplayer_internal.db") -> {
                                     exoDb.parentFile?.mkdirs()
                                     exoDb.outputStream().buffered().use { zipIn.copyTo(it) }
                                 }
-                                name == "exoplayer_internal.db-wal" || name.endsWith("/exoplayer_internal.db-wal") -> {
+                                normName == "exoplayer_internal.db-wal" || normName.endsWith("/exoplayer_internal.db-wal") -> {
                                     exoDbWal.parentFile?.mkdirs()
                                     exoDbWal.outputStream().buffered().use { zipIn.copyTo(it) }
                                 }
-                                name == "cached_songs_metadata.json" || name.endsWith("/cached_songs_metadata.json") || name == "metadata.json" -> {
+                                normName == "cached_songs_metadata.json" || normName.endsWith("/cached_songs_metadata.json") || normName.endsWith("/metadata.json") || normName == "metadata.json" -> {
                                     val jsonStr = zipIn.readBytes().toString(Charsets.UTF_8)
                                     val array = JSONArray(jsonStr)
                                     for (i in 0 until array.length()) {
@@ -627,6 +631,7 @@ class BackupRestoreViewModel @Inject constructor(
                                                 artists.add(artistsArray.getString(j))
                                             }
                                         }
+                                        restoredSongIds.add(id)
                                         val mediaMetadata = MediaMetadata(
                                             id = id,
                                             title = title,
@@ -680,6 +685,17 @@ class BackupRestoreViewModel @Inject constructor(
                         }
                     }
                 }
+
+                if (restoredSongIds.isNotEmpty()) {
+                    tryOrNull {
+                        val restoredFile = context.filesDir.resolve("restored_cache_ids.json")
+                        restoredFile.writeText(JSONArray(restoredSongIds).toString())
+                    }
+                }
+
+                // Align cache UIDs with restored database tables
+                com.darkxvenom.airbeats.di.AppModule.ensureCacheUidAligned(context, "exoplayer")
+                com.darkxvenom.airbeats.di.AppModule.ensureCacheUidAligned(context, "download")
 
                 // Checkpoint database to flush restored entries
                 database.checkpoint()

--- a/app/src/main/java/com/darkxvenom/airbeats/viewmodels/BackupRestoreViewModel.kt
+++ b/app/src/main/java/com/darkxvenom/airbeats/viewmodels/BackupRestoreViewModel.kt
@@ -458,14 +458,14 @@ class BackupRestoreViewModel @Inject constructor(
                         }
 
                         // 4. Backup cached song metadata and formats
-                        val allSongs = runCatching { database.songsByNameAsc().first() }.getOrDefault(emptyList())
+                        val allSongs = runCatching { database.allSongs().first() }.getOrDefault(emptyList())
                         val songJsonArray = JSONArray()
                         for (song in allSongs) {
                             val format = runCatching { database.format(song.id).first() }.getOrNull()
                             val obj = JSONObject().apply {
                                 put("id", song.id)
                                 put("title", song.title)
-                                put("duration", song.duration)
+                                put("duration", song.song.duration)
                                 put("thumbnailUrl", song.thumbnailUrl)
                                 put("artists", JSONArray(song.artists.map { it.name }))
                                 if (format != null) {
@@ -572,7 +572,7 @@ class BackupRestoreViewModel @Inject constructor(
                                                         mimeType = obj.getString("mimeType"),
                                                         codecs = obj.getString("codecs"),
                                                         bitrate = obj.getInt("bitrate"),
-                                                        sampleRate = obj.getInt("sampleRate"),
+                                                        sampleRate = if (obj.has("sampleRate") && !obj.isNull("sampleRate")) obj.getInt("sampleRate") else null,
                                                         contentLength = obj.getLong("contentLength"),
                                                         loudnessDb = if (obj.has("loudnessDb") && !obj.isNull("loudnessDb")) obj.getDouble("loudnessDb") else null,
                                                         playbackUrl = if (obj.has("playbackUrl") && !obj.isNull("playbackUrl")) obj.getString("playbackUrl") else null

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -389,6 +389,8 @@
     <string name="audio_normalization">Audio normalization</string>
     <string name="auto_skip_next_on_error">Auto skip to next song when error occurs</string>
     <string name="auto_skip_next_on_error_desc">Ensure your continuous playback experience</string>
+    <string name="skip_uncached_part">Skip uncached songs offline</string>
+    <string name="skip_uncached_part_desc">Skip to next track instead of pausing when playing uncached or partially cached songs offline</string>
     <string name="stop_music_on_task_clear">Stop music on task clear</string>
     <string name="equalizer">Equalizer</string>
     <string name="equalizer_in_app_description">Shape the current playback inside AirBeats.</string>
@@ -540,6 +542,14 @@
 
     <string name="backup_description">Create a backup file of your current data</string>
     <string name="restore_description">Recover your data from a backup file</string>
+    <string name="backup_cached_songs">Backup cached songs</string>
+    <string name="backup_cached_songs_desc">Export cached songs and offline audio to a backup file</string>
+    <string name="restore_cached_songs">Restore cached songs</string>
+    <string name="restore_cached_songs_desc">Import cached audio archive to restore offline music</string>
+    <string name="backup_cache_success">Cached songs backup created successfully</string>
+    <string name="backup_cache_failed">Failed to backup cached songs</string>
+    <string name="restore_cache_success">Cached songs restored successfully! Restarting...</string>
+    <string name="restore_cache_failed">Failed to restore cached songs</string>
     <string name="link_copied">Link Copied</string>
     <string name="redireccion">Redireccion</string>
     <string name="Version">Version</string>


### PR DESCRIPTION
## Overview
This PR introduces offline playback enhancements, cache backup & restoration, crash fixes, and general improvements.

### Changes Included
1. **Offline Skip for Uncached Songs**:
   - Added a setting under Player & Audio settings to skip tracks that are not cached when offline, preventing stalled buffering or unexpected pauses.
2. **Cache Backup & Restore**:
   - Implemented backup and restore for cached songs and playback metadata.
   - Properly aligns ExoPlayer cache UID and version registry (ExoPlayerVersions) to ensure restored .exo chunk files are preserved and never purged on startup.
   - Reconstructs cache index mapping if restoring older backups.
3. **Full Offline Audio Playback**:
   - Relaxed data source cache checks in MusicService.kt and DownloadUtil.kt so tracks with cached audio bytes play immediately offline from local storage without network requests.
   - Added reactive cache tracking in CachePlaylistScreen and StorageSettings so restored songs appear immediately in the Cached playlist.
4. **Crash Fixes**:
   - Fixed NoSuchElementException: Collection is empty crashes in OnlinePlaylistAdder.kt and YouTubeAlbumRadio.kt.

